### PR TITLE
Presets für Maßnahmenratings, Sektoren alphabetisch sortiert, Tabellenlimit auf 35

### DIFF
--- a/src/directus/presets/1.yaml
+++ b/src/directus/presets/1.yaml
@@ -1,0 +1,26 @@
+id: 1
+bookmark: null
+user: null
+role: null
+collection: ratings_measures
+search: null
+layout: tabular
+layout_query:
+  tabular:
+    limit: 35
+    fields:
+      - measure_id.sector
+      - measure_id.name
+      - status
+      - rating
+    page: 1
+    sort:
+      - measure_id.sector
+layout_options:
+  tabular:
+    widths:
+      measure_id.name: 500
+refresh_interval: null
+filter: null
+icon: bookmark
+color: null

--- a/src/directus/schema/fields/measures.sector.yaml
+++ b/src/directus/schema/fields/measures.sector.yaml
@@ -29,16 +29,16 @@ meta:
     choices:
       - text: $t:measure_categories.energie.title
         value: energy
+      - text: $t:measure_sectors.bh.title
+        value: bh
+      - text: $t:measure_sectors.iec.title
+        value: iec
+      - text: $t:measure_sectors.cpma.title
+        value: cpma
       - text: $t:measure_sectors.ann.title
         value: ann
       - text: $t:measure_sectors.transport.title
         value: transport
-      - text: $t:measure_sectors.iec.title
-        value: iec
-      - text: $t:measure_sectors.bh.title
-        value: bh
-      - text: $t:measure_sectors.cpma.title
-        value: cpma
   readonly: false
   required: true
   sort: 9


### PR DESCRIPTION
Impl für #163 

- Sektoren sollten jetzt alphabetisch sortiert sein
- Standardmäßig sollte bei "Maßnahmenratings" das Feld Sektor angezeigt werden (was ja sonst über Maßnahme->Sektor erst manuell hinzugefügt werden muss) und danach wird standardmäßig sortiert
- Ich hab auch mal in der YAML das Tabellenlimit von 25 auf 35 erhöht für die Maßnahmenratings, damit alle 35 Maßnahmen auf eine Seite der Tabelle passen (im Directus direkt konnte ich das nicht einstellen, nur in der YAML)