### PR TITLE
Update Directus to new major version 11

### DIFF
--- a/docker/directus/Dockerfile
+++ b/docker/directus/Dockerfile
@@ -1,4 +1,4 @@
-FROM directus/directus:10
+FROM directus/directus:11
 
 COPY build.sh /build.sh
 COPY start_dev.sh /start_dev.sh

--- a/src/directus/schema/header.yaml
+++ b/src/directus/schema/header.yaml
@@ -1,3 +1,3 @@
 version: 1
-directus: 10.13.4
+directus: 11.3.2
 vendor: postgres


### PR DESCRIPTION
Runs locally;
Please check against breaking changes for major version: https://github.com/directus/directus/releases/tag/v11.0.0 (and the other v11.x.x breaking changes)