### PR TITLE
measure_id read permission for admin- and editor localteam added. #202

### DIFF
--- a/src/directus/roles/AdminLokalteam.yaml
+++ b/src/directus/roles/AdminLokalteam.yaml
@@ -138,6 +138,7 @@ permissions:
       - description_funding
       - description_tutorial
       - slug
+      - measure_id
   - collection: directus_users
     action: read
     permissions:

--- a/src/directus/roles/EditorLocalteam.yaml
+++ b/src/directus/roles/EditorLocalteam.yaml
@@ -134,6 +134,7 @@ permissions:
       - description_funding
       - description_tutorial
       - slug
+      - measure_id
   - collection: directus_users
     action: read
     permissions:


### PR DESCRIPTION
Behebt #202 

Editor und Admin Lokalteam haben jetzt leseberechtigungen für das measure_id feld der measure tabelle.