### PR TITLE
remove ImplementationTrafficLight in municipalities page

### DIFF
--- a/src/frontend/pages/municipalities/index.vue
+++ b/src/frontend/pages/municipalities/index.vue
@@ -8,9 +8,6 @@
         {{ $t("municipalities.last_updated_at") + lastUpdatedAtStr }}
       </p>
     </div>
-    <div class="mx-auto mb-8 flex justify-center">
-      <implementation-traffic-light />
-    </div>
     <section>
       <the-ranking :municipalities="municipalities"></the-ranking>
     </section>


### PR DESCRIPTION
On the municipalities page, the ImplementationTrafficLight component has been removed. (Issue #205)