### PR TITLE
makes plausible analytics optional and configurable

### DIFF
--- a/src/frontend/.env.example
+++ b/src/frontend/.env.example
@@ -5,3 +5,5 @@ PUBLIC_URL=http://localhost:8080
 FALLBACK_LOCALE=de-DE
 HOST=0.0.0.0
 DIRECTUS_TOKEN=frontend-dev-token
+PLAUSIBLE_ANALYTICS_URL=url_to_plausible_analytics_instance
+PLAUSIBLE_ANALYTICS_DOMAIN=domain_as_registered_in_plausible_analytics

--- a/src/frontend/layouts/default.vue
+++ b/src/frontend/layouts/default.vue
@@ -43,7 +43,7 @@
         :pages="pages.filter((page) => includes(page.menus, 'footer'))"
       />
      </div>
-    
+
   </div>
 </template>
 
@@ -53,7 +53,7 @@
 
 import lodash from "lodash";
 const { includes } = lodash;
-const { $directus, $readItems, $appEnv } = useNuxtApp();
+const { $directus, $readItems, $appEnv, $plausibleAnalyticsUrl, $plausibleAnalyticsDomain } = useNuxtApp();
 
 const { data: pages } = await useAsyncData("pages", () => {
   return $directus.request($readItems("pages", { sort: "sort_order", limit: -1 }));
@@ -70,11 +70,11 @@ useHead({
   ],
   link: [{ rel: "icon", type: "image/png", href: "/favicon.png" }],
   script: [
-    $appEnv === "production"
+    $plausibleAnalyticsUrl && $plausibleAnalyticsDomain
       ? {
           defer: true,
-          "data-domain": "stadt-land-klima.de",
-          src: "https://plausible.anzui.dev/js/script.js",
+          "data-domain": $plausibleAnalyticsDomain,
+          src: $plausibleAnalyticsUrl + "/js/script.js",
         }
       : {},
   ],

--- a/src/frontend/nuxt.config.ts
+++ b/src/frontend/nuxt.config.ts
@@ -8,6 +8,8 @@ export default defineNuxtConfig({
       clientDirectusUrl: process.env.CLIENT_DIRECTUS_URL,
       serverDirectusUrl: process.env.SERVER_DIRECTUS_URL,
       appEnv: process.env.APP_ENV,
+      plausibleAnalyticsUrl: process.env.PLAUSIBLE_ANALYTICS_URL,
+      plausibleAnalyticsDomain: process.env.PLAUSIBLE_ANALYTICS_DOMAIN,
     },
   },
   devtools: { enabled: true },


### PR DESCRIPTION
To enable it you must set the new env vars in the `/src/frontend/.env`:

Example to use current plausible analytics server

```
PLAUSIBLE_ANALYTICS_URL=https://plausible.anzui.dev
PLAUSIBLE_ANALYTICS_DOMAIN=stadt-land-klima.de
```