### PR TITLE
Diverses feedback einbauen

### DIFF
--- a/src/directus/roles/AdminLokalteam.yaml
+++ b/src/directus/roles/AdminLokalteam.yaml
@@ -223,3 +223,122 @@ permissions:
     presets: null
     fields:
       - public_contact
+  - collection: articles
+    action: read
+    permissions:
+      _and:
+        - _or:
+            - status:
+                _eq: published
+            - user_created:
+                _eq: $CURRENT_USER
+    validation: null
+    presets: null
+    fields:
+      - title
+      - status
+      - slug
+      - user_created
+      - user_updated
+      - date_updated
+      - author
+      - date_created
+      - municipality_name
+      - state
+      - content
+      - subtitle
+      - image
+      - image_credits
+      - abstract
+      - article_text
+      - organisation
+      - link
+      - id
+  - collection: articles
+    action: update
+    permissions:
+      _and:
+        - _and:
+            - user_created:
+                _eq: $CURRENT_USER
+            - status:
+                _eq: draft
+    validation: null
+    presets: null
+    fields:
+      - title
+      - slug
+      - author
+      - municipality_name
+      - state
+      - content
+      - subtitle
+      - image
+      - image_credits
+      - abstract
+      - article_text
+      - organisation
+      - link
+  - collection: articles
+    action: create
+    permissions: null
+    validation: null
+    presets: null
+    fields:
+      - title
+      - slug
+      - author
+      - municipality_name
+      - state
+      - content
+      - subtitle
+      - image
+      - image_credits
+      - abstract
+      - article_text
+      - organisation
+      - link
+  - collection: articles
+    action: delete
+    permissions:
+      _and:
+        - _and:
+            - user_created:
+                _eq: $CURRENT_USER
+            - status:
+                _neq: published
+    validation: null
+    presets: null
+    fields: null
+  - collection: organisations
+    action: read
+    permissions: null
+    validation: null
+    presets: null
+    fields:
+      - name
+      - short_description
+      - link
+      - logo
+      - id
+  - collection: directus_files
+    action: create
+    permissions: {}
+    validation: {}
+    presets: null
+    fields:
+      - "*"
+  - collection: directus_files
+    action: read
+    permissions: {}
+    validation: {}
+    presets: null
+    fields:
+      - "*"
+  - collection: directus_folders
+    action: read
+    permissions: {}
+    validation: {}
+    presets: null
+    fields:
+      - "*"

--- a/src/directus/roles/EditorLocalteam.yaml
+++ b/src/directus/roles/EditorLocalteam.yaml
@@ -165,3 +165,122 @@ permissions:
     presets: null
     fields:
       - password
+  - collection: articles
+    action: read
+    permissions:
+      _and:
+        - _or:
+            - status:
+                _eq: published
+            - user_created:
+                _eq: $CURRENT_USER
+    validation: null
+    presets: null
+    fields:
+      - title
+      - status
+      - slug
+      - user_created
+      - user_updated
+      - date_updated
+      - author
+      - date_created
+      - municipality_name
+      - state
+      - content
+      - subtitle
+      - image
+      - image_credits
+      - abstract
+      - article_text
+      - organisation
+      - link
+      - id
+  - collection: articles
+    action: update
+    permissions:
+      _and:
+        - _and:
+            - user_created:
+                _eq: $CURRENT_USER
+            - status:
+                _eq: draft
+    validation: null
+    presets: null
+    fields:
+      - title
+      - slug
+      - author
+      - municipality_name
+      - state
+      - content
+      - subtitle
+      - image
+      - image_credits
+      - abstract
+      - article_text
+      - organisation
+      - link
+  - collection: articles
+    action: create
+    permissions: null
+    validation: null
+    presets: null
+    fields:
+      - title
+      - slug
+      - author
+      - municipality_name
+      - state
+      - content
+      - subtitle
+      - image
+      - image_credits
+      - abstract
+      - article_text
+      - organisation
+      - link
+  - collection: articles
+    action: delete
+    permissions:
+      _and:
+        - _and:
+            - user_created:
+                _eq: $CURRENT_USER
+            - status:
+                _neq: published
+    validation: null
+    presets: null
+    fields: null
+  - collection: organisations
+    action: read
+    permissions: null
+    validation: null
+    presets: null
+    fields:
+      - name
+      - short_description
+      - link
+      - logo
+      - id
+  - collection: directus_files
+    action: create
+    permissions: {}
+    validation: {}
+    presets: null
+    fields:
+      - "*"
+  - collection: directus_files
+    action: read
+    permissions: {}
+    validation: {}
+    presets: null
+    fields:
+      - "*"
+  - collection: directus_folders
+    action: read
+    permissions: {}
+    validation: {}
+    presets: null
+    fields:
+      - "*"

--- a/src/directus/roles/EditorLocalteam.yaml
+++ b/src/directus/roles/EditorLocalteam.yaml
@@ -108,6 +108,7 @@ permissions:
       - party_mayor
       - description
       - overall_status_comment
+      - status
   - collection: measures
     action: read
     permissions:

--- a/src/directus/schema/fields/articles.author.yaml
+++ b/src/directus/schema/fields/articles.author.yaml
@@ -11,7 +11,8 @@ meta:
   hidden: false
   interface: input
   note: null
-  options: null
+  options:
+    trim: true
   readonly: false
   required: true
   sort: 8

--- a/src/directus/schema/fields/articles.link.yaml
+++ b/src/directus/schema/fields/articles.link.yaml
@@ -13,6 +13,7 @@ meta:
   note: null
   options:
     placeholder: $t:article.link
+    trim: true
   readonly: false
   required: false
   sort: 14

--- a/src/directus/schema/fields/articles.slug.yaml
+++ b/src/directus/schema/fields/articles.slug.yaml
@@ -13,6 +13,7 @@ meta:
   note: null
   options:
     slug: true
+    trim: true
   readonly: false
   required: true
   sort: 4

--- a/src/directus/schema/fields/articles.subtitle.yaml
+++ b/src/directus/schema/fields/articles.subtitle.yaml
@@ -13,6 +13,7 @@ meta:
   note: null
   options:
     placeholder: null
+    trim: true
   readonly: false
   required: false
   sort: 1

--- a/src/directus/schema/fields/articles.title.yaml
+++ b/src/directus/schema/fields/articles.title.yaml
@@ -13,6 +13,7 @@ meta:
   note: null
   options:
     placeholder: null
+    trim: true
   readonly: false
   required: true
   sort: 3

--- a/src/directus/schema/fields/editors.email.yaml
+++ b/src/directus/schema/fields/editors.email.yaml
@@ -11,7 +11,8 @@ meta:
   hidden: false
   interface: input
   note: null
-  options: null
+  options:
+    trim: true
   readonly: false
   required: true
   sort: 6

--- a/src/directus/schema/fields/editors.internal_comment.yaml
+++ b/src/directus/schema/fields/editors.internal_comment.yaml
@@ -11,7 +11,8 @@ meta:
   hidden: false
   interface: input-multiline
   note: null
-  options: null
+  options:
+    trim: true
   readonly: false
   required: false
   sort: 9

--- a/src/directus/schema/fields/editors.organisation.yaml
+++ b/src/directus/schema/fields/editors.organisation.yaml
@@ -11,7 +11,8 @@ meta:
   hidden: false
   interface: input
   note: null
-  options: null
+  options:
+    trim: true
   readonly: false
   required: false
   sort: 8

--- a/src/directus/schema/fields/feedback.sender_contact.yaml
+++ b/src/directus/schema/fields/feedback.sender_contact.yaml
@@ -11,7 +11,8 @@ meta:
   hidden: false
   interface: input
   note: null
-  options: null
+  options:
+    trim: true
   readonly: false
   required: true
   sort: 10

--- a/src/directus/schema/fields/feedback.sender_name.yaml
+++ b/src/directus/schema/fields/feedback.sender_name.yaml
@@ -11,7 +11,8 @@ meta:
   hidden: false
   interface: input
   note: null
-  options: null
+  options:
+    trim: true
   readonly: false
   required: true
   sort: 9

--- a/src/directus/schema/fields/feedback.title.yaml
+++ b/src/directus/schema/fields/feedback.title.yaml
@@ -11,7 +11,8 @@ meta:
   hidden: false
   interface: input
   note: null
-  options: null
+  options:
+    trim: true
   readonly: false
   required: true
   sort: 6

--- a/src/directus/schema/fields/localteams.internal_comment.yaml
+++ b/src/directus/schema/fields/localteams.internal_comment.yaml
@@ -11,7 +11,8 @@ meta:
   hidden: false
   interface: input-multiline
   note: null
-  options: null
+  options:
+    trim: true
   readonly: false
   required: false
   sort: 14

--- a/src/directus/schema/fields/localteams.municipality_name.yaml
+++ b/src/directus/schema/fields/localteams.municipality_name.yaml
@@ -11,7 +11,8 @@ meta:
   hidden: false
   interface: input
   note: null
-  options: null
+  options:
+    trim: true
   readonly: false
   required: true
   sort: 10

--- a/src/directus/schema/fields/localteams.name.yaml
+++ b/src/directus/schema/fields/localteams.name.yaml
@@ -11,7 +11,8 @@ meta:
   hidden: false
   interface: input
   note: null
-  options: null
+  options:
+    trim: true
   readonly: false
   required: true
   sort: 8

--- a/src/directus/schema/fields/localteams.slug.yaml
+++ b/src/directus/schema/fields/localteams.slug.yaml
@@ -13,6 +13,7 @@ meta:
   note: null
   options:
     slug: true
+    trim: true
   readonly: false
   required: false
   sort: 9

--- a/src/directus/schema/fields/measures.measure_id.yaml
+++ b/src/directus/schema/fields/measures.measure_id.yaml
@@ -13,6 +13,7 @@ meta:
   note: null
   options:
     placeholder: z.B. EN_2
+    trim: true
   readonly: false
   required: false
   sort: 2

--- a/src/directus/schema/fields/measures.name.yaml
+++ b/src/directus/schema/fields/measures.name.yaml
@@ -11,7 +11,8 @@ meta:
   hidden: false
   interface: input
   note: null
-  options: null
+  options:
+    trim: true
   readonly: false
   required: true
   sort: 7

--- a/src/directus/schema/fields/measures.notes.yaml
+++ b/src/directus/schema/fields/measures.notes.yaml
@@ -11,7 +11,8 @@ meta:
   hidden: false
   interface: input-multiline
   note: null
-  options: null
+  options:
+    trim: true
   readonly: false
   required: false
   sort: 20

--- a/src/directus/schema/fields/municipalities.description.yaml
+++ b/src/directus/schema/fields/municipalities.description.yaml
@@ -11,7 +11,8 @@ meta:
   hidden: false
   interface: input-multiline
   note: null
-  options: null
+  options:
+    trim: true
   readonly: false
   required: false
   sort: 1

--- a/src/directus/schema/fields/municipalities.id.yaml
+++ b/src/directus/schema/fields/municipalities.id.yaml
@@ -11,7 +11,8 @@ meta:
   hidden: true
   interface: input
   note: null
-  options: null
+  options:
+    trim: true
   readonly: true
   required: false
   sort: 2

--- a/src/directus/schema/fields/municipalities.mayor.yaml
+++ b/src/directus/schema/fields/municipalities.mayor.yaml
@@ -11,7 +11,8 @@ meta:
   hidden: false
   interface: input
   note: null
-  options: null
+  options:
+    trim: true
   readonly: false
   required: false
   sort: 4

--- a/src/directus/schema/fields/municipalities.name.yaml
+++ b/src/directus/schema/fields/municipalities.name.yaml
@@ -11,7 +11,8 @@ meta:
   hidden: false
   interface: input
   note: null
-  options: null
+  options:
+    trim: true
   readonly: false
   required: true
   sort: 8

--- a/src/directus/schema/fields/municipalities.party_mayor.yaml
+++ b/src/directus/schema/fields/municipalities.party_mayor.yaml
@@ -11,7 +11,8 @@ meta:
   hidden: false
   interface: input
   note: null
-  options: null
+  options:
+    trim: true
   readonly: false
   required: false
   sort: 5

--- a/src/directus/schema/fields/municipalities.slug.yaml
+++ b/src/directus/schema/fields/municipalities.slug.yaml
@@ -13,6 +13,7 @@ meta:
   note: null
   options:
     slug: true
+    trim: true
   readonly: false
   required: false
   sort: 9

--- a/src/directus/schema/fields/organisations.link.yaml
+++ b/src/directus/schema/fields/organisations.link.yaml
@@ -11,7 +11,8 @@ meta:
   hidden: false
   interface: input
   note: null
-  options: null
+  options:
+    trim: true
   readonly: false
   required: true
   sort: 9

--- a/src/directus/schema/fields/organisations.name.yaml
+++ b/src/directus/schema/fields/organisations.name.yaml
@@ -11,7 +11,8 @@ meta:
   hidden: false
   interface: input
   note: null
-  options: null
+  options:
+    trim: true
   readonly: false
   required: true
   sort: 7

--- a/src/directus/schema/fields/organisations.short_description.yaml
+++ b/src/directus/schema/fields/organisations.short_description.yaml
@@ -13,6 +13,7 @@ meta:
   note: null
   options:
     softLength: 500
+    trim: true
   readonly: false
   required: false
   sort: 8

--- a/src/directus/schema/fields/pages.name.yaml
+++ b/src/directus/schema/fields/pages.name.yaml
@@ -11,7 +11,8 @@ meta:
   hidden: false
   interface: input
   note: null
-  options: null
+  options:
+    trim: true
   readonly: false
   required: true
   sort: 7

--- a/src/directus/schema/fields/pages.slug.yaml
+++ b/src/directus/schema/fields/pages.slug.yaml
@@ -13,6 +13,7 @@ meta:
   note: null
   options:
     slug: true
+    trim: true
   readonly: false
   required: false
   sort: 8

--- a/src/directus/schema/fields/ratings_measures.current_progress.yaml
+++ b/src/directus/schema/fields/ratings_measures.current_progress.yaml
@@ -27,6 +27,7 @@ meta:
     clear: true
     placeholder: $t:measure_rating.progress.placeholder
     softLength: 1500
+    trim: true
   readonly: false
   required: true
   sort: 16

--- a/src/directus/schema/fields/ratings_measures.date_updated.yaml
+++ b/src/directus/schema/fields/ratings_measures.date_updated.yaml
@@ -18,12 +18,12 @@ meta:
   sort: 7
   special:
     - date-updated
-  validation: null
-  validation_message: null
-  width: half
   translations:
     - language: de-DE
       translation: Zuletzt bearbeitet
+  validation: null
+  validation_message: null
+  width: half
 schema:
   name: date_updated
   table: ratings_measures

--- a/src/directus/schema/fields/ratings_measures.source.yaml
+++ b/src/directus/schema/fields/ratings_measures.source.yaml
@@ -25,6 +25,7 @@ meta:
   note: null
   options:
     softLength: 500
+    trim: true
   readonly: false
   required: true
   sort: 17

--- a/src/directus/schema/fields/ratings_measures.why_not_applicable.yaml
+++ b/src/directus/schema/fields/ratings_measures.why_not_applicable.yaml
@@ -24,6 +24,7 @@ meta:
   note: null
   options:
     placeholder: $t:measure_rating.why_not_applicable.placeholder
+    trim: true
   readonly: false
   required: false
   sort: 13


### PR DESCRIPTION
- Bei allen Feldern wird jetzt der whitespace am Anfang/Ende getrimmed
- Alle Mitglieder eines Lokalteams können jetzt ihre Kommune veröffentlichen, nicht nur der LokalteamAdmin
- Folgende Änderung an den Berechtigungen bzgl der Erfolgsprojekte-Redaktion

> Lokalteam-Nutzer können jetzt (egal ob LokalteamAdmin oder Editor) folgende Dinge tun:
> 
> Eigene Artikel erstellen und bearbeiten
> Andere Artikel im Status "Veröffentlicht" im Directus lesen
> Die "Organisations"-Collection sehen
> Sie können nicht:
> 
> Ihre Artikel selbst auf "veröffentlicht" setzen (das muss jemand mit der Rolle "EditorArticles" / aus unserem Redaktionsteam entscheiden)
> Artikel, die schon veröffentlicht sind, bearbeiten.
> Artikel anderer Personen bearbeiten
> Organisationen erstellen oder bearbeiten