### PR TITLE
286 Map height and dock positon

### DIFF
--- a/src/frontend/components/TheMap.vue
+++ b/src/frontend/components/TheMap.vue
@@ -7,7 +7,7 @@
   </div>
 
   <ClientOnly>
-    <div class="w-full h-screen z-0">
+    <div class="w-full h-[75svh] z-0">
       <LMap
         v-if="clientReady"
         :zoom="6"

--- a/src/frontend/layouts/default.vue
+++ b/src/frontend/layouts/default.vue
@@ -34,6 +34,7 @@
         <the-footer-mobile
           :pages="pages.filter((page) => includes(page.menus, 'footer'))"
         />
+        <div class="h-[48px]"></div> <!-- Spacer to accommodate the dock height -->
       </div>
 
       <!-- Footer (Desktop version) -->
@@ -50,7 +51,7 @@
     />
 
     <!-- Dock (Mobile version - always visible, sticky) -->
-    <div class="fixed bottom-0 left-0 right-0 z-50 block lg:hidden">
+    <div class="fixed bottom-0 left-0 right-0 z-[2000] block lg:hidden">
       <the-dock :pages="pages.filter((page) => includes(page.menus, 'dock'))" />
     </div>
   </div>


### PR DESCRIPTION
Closes #286 
- Set map height from 100vh to 75vh
- Adjust footer z-index
- Added spacer at the bottom so that the dock does not cover parts of the footer.  