### PR TITLE
312 Export/Import CLI Script for Dashboards

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,6 +39,7 @@ services:
     env_file: ./src/directus/.env
     volumes:
       - ./src/directus/uploads:/directus/uploads
+      - ./src/directus/dashboards/:/directus/dashboards
       - ./src/directus/extensions:/directus/extensions
       - ./src/directus/schema/:/directus/schema
       - ./src/directus/roles/:/directus/roles

--- a/src/directus/cli/README.md
+++ b/src/directus/cli/README.md
@@ -59,6 +59,7 @@ This will export:
 5. `presets/` - Preset definitions
 6. `translations/` - Translation files
 7. `settings/` - Settings
+8. `dashboards/` - Dashboard and panel definitions
 
 ### Import All Configuration
 
@@ -74,6 +75,9 @@ This will import in the correct order:
 5. Presets
 6. Translations
 7. Settings
+
+Dashboards are intentionally not imported by `import:all` at the moment.
+Use `import:dashboards` manually when dashboard imports are enabled for an environment.
 
 ### Individual Commands
 
@@ -98,6 +102,16 @@ This will import in the correct order:
 ```
 
 > **Note:** Policies must be imported before roles, as roles reference policies by ID.
+
+#### Export Dashboards
+```bash
+./directus-cli export:dashboards /path/to/dashboards
+```
+
+#### Import Dashboards
+```bash
+./directus-cli import:dashboards /path/to/dashboards
+```
 
 ## Command Line Options
 

--- a/src/directus/cli/export-all.sh
+++ b/src/directus/cli/export-all.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/.." || exit 1
+
 # Use the new export:all command which clears cache once and exports sequentially
-./directus-cli -f -c export:all
+"$SCRIPT_DIR/index.mjs" -f -c export:all
 
 echo "All exports completed"

--- a/src/directus/cli/import-all.sh
+++ b/src/directus/cli/import-all.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/.." || exit 1
+
 # Use the new import:all command which clears cache once and imports sequentially
-./directus-cli -f -r import:all
+"$SCRIPT_DIR/index.mjs" -f -r import:all
 
 echo "All imports completed"

--- a/src/directus/cli/tasks/export/exportDashboards.mjs
+++ b/src/directus/cli/tasks/export/exportDashboards.mjs
@@ -1,0 +1,91 @@
+import fse from 'fse';
+import fs from 'fs';
+import path from 'path';
+import { stringify } from 'yaml';
+import { readDashboards, readPanels } from '@directus/sdk';
+import slugify from 'slugify';
+import createDirectusClient from '../shared/createDirectusClient.mjs';
+
+function cleanDashboard(dashboard) {
+  const clean = { ...dashboard };
+
+  delete clean.id;
+  delete clean.date_created;
+  delete clean.date_updated;
+  delete clean.user_created;
+  delete clean.user_updated;
+
+  return clean;
+}
+
+function cleanPanel(panel) {
+  const clean = { ...panel };
+
+  delete clean.id;
+  delete clean.dashboard;
+  delete clean.date_created;
+  delete clean.date_updated;
+  delete clean.user_created;
+  delete clean.user_updated;
+
+  return clean;
+}
+
+function getDashboardId(value) {
+  return typeof value === 'object' && value !== null ? value.id : value;
+}
+
+function sortPanels(a, b) {
+  return (
+    (a.position_y ?? 0) - (b.position_y ?? 0) ||
+    (a.position_x ?? 0) - (b.position_x ?? 0) ||
+    String(a.name ?? '').localeCompare(String(b.name ?? ''))
+  );
+}
+
+async function exportDashboards(dest, options = { verbose: false, overwrite: false }) {
+  const client = createDirectusClient();
+
+  try {
+    const dashboards = await client.request(readDashboards({ limit: -1 }));
+    const panels = await client.request(readPanels({ limit: -1 }));
+
+    fs.mkdirSync(dest, { recursive: true });
+
+    dashboards
+      .sort((a, b) => String(a.name ?? '').localeCompare(String(b.name ?? '')))
+      .forEach((dashboard) => {
+        const dashboardPanels = panels
+          .filter((panel) => getDashboardId(panel.dashboard) === dashboard.id)
+          .map(cleanPanel)
+          .sort(sortPanels);
+        const dashboardData = {
+          ...cleanDashboard(dashboard),
+          panels: dashboardPanels,
+        };
+        const destPath = path.join(dest, slugify(dashboard.name, { replacement: '_', lower: false }) + '.yaml');
+
+        if (!options.overwrite && fse.existsSync(destPath)) {
+          if (options.verbose) {
+            console.info(`File ${destPath} already exists.`);
+          }
+          return;
+        }
+
+        fse.writeFileSync(destPath, stringify(dashboardData), { encoding: 'utf8' });
+
+        if (options.verbose) {
+          console.info(`Exported dashboard ${destPath}`);
+        }
+      });
+
+    if (options.verbose) {
+      console.info(`Exported ${dashboards.length} dashboards.`);
+    }
+  } catch (err) {
+    console.error(err);
+    return process.exit(1);
+  }
+}
+
+export default exportDashboards;

--- a/src/directus/cli/tasks/export/index.mjs
+++ b/src/directus/cli/tasks/export/index.mjs
@@ -11,6 +11,7 @@ import exportFlows from './exportFlows.mjs';
 import exportTranslations from './exportTranslations.mjs';
 import exportSettings from './exportSettings.mjs';
 import exportCollectionItems from './exportCollectionItems.mjs';
+import exportDashboards from './exportDashboards.mjs';
 
 const clerDirOpts = {extensions: ['.yaml']};
 
@@ -235,8 +236,37 @@ function exportTasks(yargs) {
   )
 
   .command(
+    'export:dashboards [dest]',
+    'export all dashboards to the folder specified by "dest". By default it will export into "dashboards"',
+    (yargs) => {
+      return yargs
+      .positional('dest', {
+        describe: 'destination folder',
+        default: 'dashboards',
+      });
+    },
+    async (argv) => {
+      if (argv.verbose) {
+        console.info(`Exporting dashboards to ${argv.dest}`);
+      }
+      if (argv.clear) {
+        clear(argv.dest, {
+          verbose: argv.verbose,
+        });
+      }
+
+      await clearDirectusCache();
+      await exportDashboards(argv.dest, {
+        verbose: argv.verbose,
+        overwrite: argv.force,
+      });
+    }
+  )
+
+  .command(
     'export:all [dest]',
-    'export schema, policies, roles, flows, presets, translations, and settings consecutively. In v11+, policies are exported separately from roles.',
+    'export schema, policies, roles, flows, presets, translations, settings, and dashboards consecutively. ' +
+      'In v11+, policies are exported separately from roles.',
     (yargs) => {
       return yargs
       .positional('dest', {
@@ -320,6 +350,16 @@ function exportTasks(yargs) {
         clear(path.join(dest, 'settings'), { verbose: argv.verbose });
       }
       await exportSettings(path.join(dest, 'settings'), {
+        verbose: argv.verbose,
+        overwrite: argv.force,
+      });
+
+      // Export dashboards
+      console.info('Exporting dashboards...');
+      if (argv.clear) {
+        clear(path.join(dest, 'dashboards'), { verbose: argv.verbose });
+      }
+      await exportDashboards(path.join(dest, 'dashboards'), {
         verbose: argv.verbose,
         overwrite: argv.force,
       });

--- a/src/directus/cli/tasks/import/importDashboards.mjs
+++ b/src/directus/cli/tasks/import/importDashboards.mjs
@@ -1,0 +1,146 @@
+import path from 'path';
+import {
+  createDashboard,
+  createPanels,
+  deleteDashboards,
+  deletePanels,
+  readDashboards,
+  readPanels,
+  updateDashboard,
+} from '@directus/sdk';
+import createDirectusClient from '../shared/createDirectusClient.mjs';
+import readYamlFiles from '../shared/readYamlFiles.mjs';
+
+function getDashboardId(value) {
+  return typeof value === 'object' && value !== null ? value.id : value;
+}
+
+function cleanDashboardForImport(dashboard) {
+  const clean = { ...dashboard };
+
+  delete clean.id;
+  delete clean.panels;
+  delete clean.date_created;
+  delete clean.date_updated;
+  delete clean.user_created;
+  delete clean.user_updated;
+
+  return clean;
+}
+
+function cleanPanelForImport(panel, dashboardId) {
+  const clean = { ...panel };
+
+  delete clean.id;
+  delete clean.date_created;
+  delete clean.date_updated;
+  delete clean.user_created;
+  delete clean.user_updated;
+  clean.dashboard = dashboardId;
+
+  return clean;
+}
+
+async function replaceDashboardPanels(client, dashboardId, panels, existingPanels, options) {
+  const panelsToDelete = existingPanels.filter((panel) => getDashboardId(panel.dashboard) === dashboardId);
+
+  if (panelsToDelete.length) {
+    if (options.verbose) {
+      console.info(`Deleting ${panelsToDelete.length} existing dashboard panels`);
+    }
+
+    const panelIdsToDelete = panelsToDelete.map((panel) => panel.id).filter((id) => id && id !== '');
+
+    if (panelIdsToDelete.length) {
+      await client.request(deletePanels(panelIdsToDelete));
+    }
+  }
+
+  if (!panels.length) {
+    return;
+  }
+
+  if (options.verbose) {
+    console.info(`Creating ${panels.length} dashboard panels`);
+  }
+
+  await client.request(createPanels(panels.map((panel) => cleanPanelForImport(panel, dashboardId))));
+}
+
+async function importDashboards(src, options = { verbose: false, overwrite: false, remove: false }) {
+  const client = createDirectusClient();
+
+  try {
+    const dashboards = readYamlFiles(path.join(src));
+    const existingDashboards = await client.request(readDashboards({ limit: -1 }));
+    const existingPanels = await client.request(readPanels({ limit: -1 }));
+    const existingDashboardsByName = new Map(existingDashboards.map((dashboard) => [dashboard.name, dashboard]));
+    const importedDashboardNames = new Set(dashboards.map((dashboard) => dashboard.name));
+
+    for (const dashboard of dashboards) {
+      const panels = dashboard.panels ?? [];
+      const existingDashboard = existingDashboardsByName.get(dashboard.name);
+      let savedDashboard = existingDashboard;
+
+      if (existingDashboard) {
+        if (!options.overwrite) {
+          if (options.verbose) {
+            console.info(`Dashboard "${dashboard.name}" already exists. Skipping.`);
+          }
+          continue;
+        }
+
+        if (options.verbose) {
+          console.info(`Updating dashboard "${dashboard.name}"`);
+        }
+
+        savedDashboard = await client.request(
+          updateDashboard(existingDashboard.id, cleanDashboardForImport(dashboard))
+        );
+      } else {
+        if (options.verbose) {
+          console.info(`Creating dashboard "${dashboard.name}"`);
+        }
+
+        savedDashboard = await client.request(createDashboard(cleanDashboardForImport(dashboard)));
+      }
+
+      await replaceDashboardPanels(client, savedDashboard.id, panels, existingPanels, options);
+    }
+
+    if (options.remove) {
+      const dashboardsToDelete = existingDashboards.filter((dashboard) => !importedDashboardNames.has(dashboard.name));
+
+      if (dashboardsToDelete.length) {
+        if (options.verbose) {
+          console.info(`Removing ${dashboardsToDelete.length} dashboards`);
+        }
+
+        const dashboardIdsToDelete = dashboardsToDelete
+          .map((dashboard) => dashboard.id)
+          .filter((id) => id && id !== '');
+        const panelIdsToDelete = existingPanels
+          .filter((panel) => dashboardIdsToDelete.includes(getDashboardId(panel.dashboard)))
+          .map((panel) => panel.id)
+          .filter((id) => id && id !== '');
+
+        if (panelIdsToDelete.length) {
+          await client.request(deletePanels(panelIdsToDelete));
+        }
+
+        if (dashboardIdsToDelete.length) {
+          await client.request(deleteDashboards(dashboardIdsToDelete));
+        }
+      }
+    }
+
+    if (options.verbose) {
+      console.info('Dashboards imported');
+    }
+  } catch (err) {
+    console.error(err);
+    return process.exit(1);
+  }
+}
+
+export default importDashboards;

--- a/src/directus/cli/tasks/import/index.mjs
+++ b/src/directus/cli/tasks/import/index.mjs
@@ -9,6 +9,7 @@ import importFlows from './importFlows.mjs';
 import importTranslations from './importTranslations.mjs';
 import importSettings from './importSettings.mjs';
 import importCollectionItems from './importCollectionItems.mjs';
+import importDashboards from './importDashboards.mjs';
 
 function importTasks(yargs) {
   return yargs
@@ -205,8 +206,33 @@ function importTasks(yargs) {
   )
 
   .command(
+    'import:dashboards [src]',
+    'imports the dashboards from the folder specified by "src". By default it will import from "dashboards"',
+    (yargs) => {
+      return yargs
+      .positional('src', {
+        describe: 'source folder',
+        default: 'dashboards',
+      });
+    },
+    async (argv) => {
+      if (argv.verbose) {
+        console.info(`Importing dashboards from ${argv.src}`);
+      }
+
+      await clearDirectusCache();
+      await importDashboards(argv.src, {
+        verbose: argv.verbose,
+        remove: argv['remove-orphans'],
+        overwrite: argv.force,
+      });
+    }
+  )
+
+  .command(
     'import:all [src]',
-    'imports schema, policies, roles, flows, presets, translations, and settings consecutively. In v11+, policies are imported before roles.',
+    'imports schema, policies, roles, flows, presets, translations, and settings consecutively. ' +
+      'Dashboards are intentionally skipped for now.',
     (yargs) => {
       return yargs
       .positional('src', {
@@ -269,6 +295,8 @@ function importTasks(yargs) {
         remove: argv['remove-orphans'],
         overwrite: argv.force,
       });
+
+      console.info('Dashboards are not imported at the moment. Run import:dashboards manually if needed.');
 
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(2);
       console.info(`Full import completed in ${elapsed}s`);


### PR DESCRIPTION
Closes #312 

Im export-all eingebaut, aber nicht im import-all, damit wir nicht die bestehenden dashboards auf prod versehentlich überschreiben