### PR TITLE
Fix submit form

### DIFF
--- a/src/directus/translations/de-DE/projects.submit.error.captcha_failed.de-DE.yaml
+++ b/src/directus/translations/de-DE/projects.submit.error.captcha_failed.de-DE.yaml
@@ -1,0 +1,3 @@
+language: de-DE
+key: projects.submit.error.captcha_failed
+value: Die CAPTCHA-Überprüfung ist fehlgeschlagen. Bitte lade die Seite neu und versuche es noch einmal.

--- a/src/directus/translations/de-DE/projects.submit.error.email_invalid.de-DE.yaml
+++ b/src/directus/translations/de-DE/projects.submit.error.email_invalid.de-DE.yaml
@@ -1,0 +1,3 @@
+language: de-DE
+key: projects.submit.error.email_invalid
+value: Bitte gib eine gültige E-Mail-Adresse ein.

--- a/src/directus/translations/de-DE/projects.submit.error.field_too_long.de-DE.yaml
+++ b/src/directus/translations/de-DE/projects.submit.error.field_too_long.de-DE.yaml
@@ -1,0 +1,3 @@
+language: de-DE
+key: projects.submit.error.field_too_long
+value: ":field darf höchstens :max Zeichen lang sein."

--- a/src/directus/translations/de-DE/projects.submit.error.image_format.de-DE.yaml
+++ b/src/directus/translations/de-DE/projects.submit.error.image_format.de-DE.yaml
@@ -1,0 +1,3 @@
+language: de-DE
+key: projects.submit.error.image_format
+value: Bitte lade ein Bild im Format JPG, PNG oder WebP hoch.

--- a/src/directus/translations/de-DE/projects.submit.error.image_invalid.de-DE.yaml
+++ b/src/directus/translations/de-DE/projects.submit.error.image_invalid.de-DE.yaml
@@ -1,0 +1,3 @@
+language: de-DE
+key: projects.submit.error.image_invalid
+value: Die Bilddatei konnte nicht validiert werden. Bitte wähle eine andere Datei aus.

--- a/src/directus/translations/de-DE/projects.submit.error.image_too_large.de-DE.yaml
+++ b/src/directus/translations/de-DE/projects.submit.error.image_too_large.de-DE.yaml
@@ -1,0 +1,3 @@
+language: de-DE
+key: projects.submit.error.image_too_large
+value: "Das Bild darf höchstens :max MB groß sein."

--- a/src/directus/translations/de-DE/projects.submit.error.invalid_submission.de-DE.yaml
+++ b/src/directus/translations/de-DE/projects.submit.error.invalid_submission.de-DE.yaml
@@ -1,0 +1,3 @@
+language: de-DE
+key: projects.submit.error.invalid_submission
+value: Die Einreichung ist ungültig. Bitte prüfe deine Eingaben und versuche es erneut.

--- a/src/directus/translations/de-DE/projects.submit.error.required_fields.de-DE.yaml
+++ b/src/directus/translations/de-DE/projects.submit.error.required_fields.de-DE.yaml
@@ -1,0 +1,3 @@
+language: de-DE
+key: projects.submit.error.required_fields
+value: Bitte fülle alle Pflichtfelder aus.

--- a/src/directus/translations/de-DE/projects.submit.error.save_failed.de-DE.yaml
+++ b/src/directus/translations/de-DE/projects.submit.error.save_failed.de-DE.yaml
@@ -1,0 +1,3 @@
+language: de-DE
+key: projects.submit.error.save_failed
+value: Die Einreichung konnte nicht gespeichert werden. Bitte versuche es später erneut.

--- a/src/directus/translations/de-DE/projects.submit.error.sectors_invalid.de-DE.yaml
+++ b/src/directus/translations/de-DE/projects.submit.error.sectors_invalid.de-DE.yaml
@@ -1,0 +1,3 @@
+language: de-DE
+key: projects.submit.error.sectors_invalid
+value: Die ausgewählten Sektoren sind ungültig. Bitte prüfe deine Auswahl.

--- a/src/directus/translations/de-DE/projects.submit.error.sectors_too_many.de-DE.yaml
+++ b/src/directus/translations/de-DE/projects.submit.error.sectors_too_many.de-DE.yaml
@@ -1,0 +1,3 @@
+language: de-DE
+key: projects.submit.error.sectors_too_many
+value: "Bitte wähle höchstens :max Sektoren aus."

--- a/src/directus/translations/de-DE/projects.submit.error.service_unavailable.de-DE.yaml
+++ b/src/directus/translations/de-DE/projects.submit.error.service_unavailable.de-DE.yaml
@@ -1,0 +1,3 @@
+language: de-DE
+key: projects.submit.error.service_unavailable
+value: Die Einreichung ist momentan nicht verfügbar. Bitte versuche es später erneut.

--- a/src/directus/translations/de-DE/projects.submit.error.state_invalid.de-DE.yaml
+++ b/src/directus/translations/de-DE/projects.submit.error.state_invalid.de-DE.yaml
@@ -1,0 +1,3 @@
+language: de-DE
+key: projects.submit.error.state_invalid
+value: Bitte wähle ein gültiges Bundesland aus.

--- a/src/directus/translations/de-DE/projects.submit.error.submission_too_large.de-DE.yaml
+++ b/src/directus/translations/de-DE/projects.submit.error.submission_too_large.de-DE.yaml
@@ -1,0 +1,3 @@
+language: de-DE
+key: projects.submit.error.submission_too_large
+value: Die gesamte Einreichung ist zu groß. Bitte wähle ein kleineres Bild aus.

--- a/src/directus/translations/de-DE/projects.submit.error.url_invalid.de-DE.yaml
+++ b/src/directus/translations/de-DE/projects.submit.error.url_invalid.de-DE.yaml
@@ -1,0 +1,3 @@
+language: de-DE
+key: projects.submit.error.url_invalid
+value: "Bitte gib für :field eine gültige URL ein."

--- a/src/directus/translations/de-DE/projects.submit.hint.image.de-DE.yaml
+++ b/src/directus/translations/de-DE/projects.submit.hint.image.de-DE.yaml
@@ -1,0 +1,3 @@
+language: de-DE
+key: projects.submit.hint.image
+value: "JPG, PNG oder WebP, maximal :max MB."

--- a/src/directus/translations/de-DE/projects.submit.hint.sectors_max.de-DE.yaml
+++ b/src/directus/translations/de-DE/projects.submit.hint.sectors_max.de-DE.yaml
@@ -1,0 +1,3 @@
+language: de-DE
+key: projects.submit.hint.sectors_max
+value: "Du kannst bis zu :max Sektoren auswählen."

--- a/src/directus/translations/en-GB/projects.submit.error.captcha_failed.en-GB.yaml
+++ b/src/directus/translations/en-GB/projects.submit.error.captcha_failed.en-GB.yaml
@@ -1,0 +1,3 @@
+language: en-GB
+key: projects.submit.error.captcha_failed
+value: CAPTCHA verification failed. Please reload the page and try again.

--- a/src/directus/translations/en-GB/projects.submit.error.email_invalid.en-GB.yaml
+++ b/src/directus/translations/en-GB/projects.submit.error.email_invalid.en-GB.yaml
@@ -1,0 +1,3 @@
+language: en-GB
+key: projects.submit.error.email_invalid
+value: Please enter a valid email address.

--- a/src/directus/translations/en-GB/projects.submit.error.field_too_long.en-GB.yaml
+++ b/src/directus/translations/en-GB/projects.submit.error.field_too_long.en-GB.yaml
@@ -1,0 +1,3 @@
+language: en-GB
+key: projects.submit.error.field_too_long
+value: ":field must be no more than :max characters long."

--- a/src/directus/translations/en-GB/projects.submit.error.image_format.en-GB.yaml
+++ b/src/directus/translations/en-GB/projects.submit.error.image_format.en-GB.yaml
@@ -1,0 +1,3 @@
+language: en-GB
+key: projects.submit.error.image_format
+value: Please upload a JPG, PNG or WebP image.

--- a/src/directus/translations/en-GB/projects.submit.error.image_invalid.en-GB.yaml
+++ b/src/directus/translations/en-GB/projects.submit.error.image_invalid.en-GB.yaml
@@ -1,0 +1,3 @@
+language: en-GB
+key: projects.submit.error.image_invalid
+value: The image file could not be validated. Please select a different file.

--- a/src/directus/translations/en-GB/projects.submit.error.image_too_large.en-GB.yaml
+++ b/src/directus/translations/en-GB/projects.submit.error.image_too_large.en-GB.yaml
@@ -1,0 +1,3 @@
+language: en-GB
+key: projects.submit.error.image_too_large
+value: "The image must be no larger than :max MB."

--- a/src/directus/translations/en-GB/projects.submit.error.invalid_submission.en-GB.yaml
+++ b/src/directus/translations/en-GB/projects.submit.error.invalid_submission.en-GB.yaml
@@ -1,0 +1,3 @@
+language: en-GB
+key: projects.submit.error.invalid_submission
+value: The submission is invalid. Please check your entries and try again.

--- a/src/directus/translations/en-GB/projects.submit.error.required_fields.en-GB.yaml
+++ b/src/directus/translations/en-GB/projects.submit.error.required_fields.en-GB.yaml
@@ -1,0 +1,3 @@
+language: en-GB
+key: projects.submit.error.required_fields
+value: Please complete all required fields.

--- a/src/directus/translations/en-GB/projects.submit.error.save_failed.en-GB.yaml
+++ b/src/directus/translations/en-GB/projects.submit.error.save_failed.en-GB.yaml
@@ -1,0 +1,3 @@
+language: en-GB
+key: projects.submit.error.save_failed
+value: The submission could not be saved. Please try again later.

--- a/src/directus/translations/en-GB/projects.submit.error.sectors_invalid.en-GB.yaml
+++ b/src/directus/translations/en-GB/projects.submit.error.sectors_invalid.en-GB.yaml
@@ -1,0 +1,3 @@
+language: en-GB
+key: projects.submit.error.sectors_invalid
+value: The selected sectors are invalid. Please check your selection.

--- a/src/directus/translations/en-GB/projects.submit.error.sectors_too_many.en-GB.yaml
+++ b/src/directus/translations/en-GB/projects.submit.error.sectors_too_many.en-GB.yaml
@@ -1,0 +1,3 @@
+language: en-GB
+key: projects.submit.error.sectors_too_many
+value: "Please select no more than :max sectors."

--- a/src/directus/translations/en-GB/projects.submit.error.service_unavailable.en-GB.yaml
+++ b/src/directus/translations/en-GB/projects.submit.error.service_unavailable.en-GB.yaml
@@ -1,0 +1,3 @@
+language: en-GB
+key: projects.submit.error.service_unavailable
+value: Submissions are currently unavailable. Please try again later.

--- a/src/directus/translations/en-GB/projects.submit.error.state_invalid.en-GB.yaml
+++ b/src/directus/translations/en-GB/projects.submit.error.state_invalid.en-GB.yaml
@@ -1,0 +1,3 @@
+language: en-GB
+key: projects.submit.error.state_invalid
+value: Please select a valid federal state.

--- a/src/directus/translations/en-GB/projects.submit.error.submission_too_large.en-GB.yaml
+++ b/src/directus/translations/en-GB/projects.submit.error.submission_too_large.en-GB.yaml
@@ -1,0 +1,3 @@
+language: en-GB
+key: projects.submit.error.submission_too_large
+value: The complete submission is too large. Please select a smaller image.

--- a/src/directus/translations/en-GB/projects.submit.error.url_invalid.en-GB.yaml
+++ b/src/directus/translations/en-GB/projects.submit.error.url_invalid.en-GB.yaml
@@ -1,0 +1,3 @@
+language: en-GB
+key: projects.submit.error.url_invalid
+value: "Please enter a valid URL for :field."

--- a/src/directus/translations/en-GB/projects.submit.hint.image.en-GB.yaml
+++ b/src/directus/translations/en-GB/projects.submit.hint.image.en-GB.yaml
@@ -1,0 +1,3 @@
+language: en-GB
+key: projects.submit.hint.image
+value: "JPG, PNG or WebP, up to :max MB."

--- a/src/directus/translations/en-GB/projects.submit.hint.sectors_max.en-GB.yaml
+++ b/src/directus/translations/en-GB/projects.submit.hint.sectors_max.en-GB.yaml
@@ -1,0 +1,3 @@
+language: en-GB
+key: projects.submit.hint.sectors_max
+value: "You can select up to :max sectors."

--- a/src/directus/translations/it-IT/projects.submit.error.captcha_failed.it-IT.yaml
+++ b/src/directus/translations/it-IT/projects.submit.error.captcha_failed.it-IT.yaml
@@ -1,0 +1,3 @@
+language: it-IT
+key: projects.submit.error.captcha_failed
+value: La verifica CAPTCHA non è riuscita. Ricarica la pagina e riprova.

--- a/src/directus/translations/it-IT/projects.submit.error.email_invalid.it-IT.yaml
+++ b/src/directus/translations/it-IT/projects.submit.error.email_invalid.it-IT.yaml
@@ -1,0 +1,3 @@
+language: it-IT
+key: projects.submit.error.email_invalid
+value: Inserisci un indirizzo email valido.

--- a/src/directus/translations/it-IT/projects.submit.error.field_too_long.it-IT.yaml
+++ b/src/directus/translations/it-IT/projects.submit.error.field_too_long.it-IT.yaml
@@ -1,0 +1,3 @@
+language: it-IT
+key: projects.submit.error.field_too_long
+value: ":field non può superare :max caratteri."

--- a/src/directus/translations/it-IT/projects.submit.error.image_format.it-IT.yaml
+++ b/src/directus/translations/it-IT/projects.submit.error.image_format.it-IT.yaml
@@ -1,0 +1,3 @@
+language: it-IT
+key: projects.submit.error.image_format
+value: Carica un'immagine in formato JPG, PNG o WebP.

--- a/src/directus/translations/it-IT/projects.submit.error.image_invalid.it-IT.yaml
+++ b/src/directus/translations/it-IT/projects.submit.error.image_invalid.it-IT.yaml
@@ -1,0 +1,3 @@
+language: it-IT
+key: projects.submit.error.image_invalid
+value: Non è stato possibile convalidare il file immagine. Seleziona un altro file.

--- a/src/directus/translations/it-IT/projects.submit.error.image_too_large.it-IT.yaml
+++ b/src/directus/translations/it-IT/projects.submit.error.image_too_large.it-IT.yaml
@@ -1,0 +1,3 @@
+language: it-IT
+key: projects.submit.error.image_too_large
+value: "L'immagine non può superare :max MB."

--- a/src/directus/translations/it-IT/projects.submit.error.invalid_submission.it-IT.yaml
+++ b/src/directus/translations/it-IT/projects.submit.error.invalid_submission.it-IT.yaml
@@ -1,0 +1,3 @@
+language: it-IT
+key: projects.submit.error.invalid_submission
+value: L'invio non è valido. Controlla i dati inseriti e riprova.

--- a/src/directus/translations/it-IT/projects.submit.error.required_fields.it-IT.yaml
+++ b/src/directus/translations/it-IT/projects.submit.error.required_fields.it-IT.yaml
@@ -1,0 +1,3 @@
+language: it-IT
+key: projects.submit.error.required_fields
+value: Compila tutti i campi obbligatori.

--- a/src/directus/translations/it-IT/projects.submit.error.save_failed.it-IT.yaml
+++ b/src/directus/translations/it-IT/projects.submit.error.save_failed.it-IT.yaml
@@ -1,0 +1,3 @@
+language: it-IT
+key: projects.submit.error.save_failed
+value: Non è stato possibile salvare l'invio. Riprova più tardi.

--- a/src/directus/translations/it-IT/projects.submit.error.sectors_invalid.it-IT.yaml
+++ b/src/directus/translations/it-IT/projects.submit.error.sectors_invalid.it-IT.yaml
@@ -1,0 +1,3 @@
+language: it-IT
+key: projects.submit.error.sectors_invalid
+value: I settori selezionati non sono validi. Controlla la selezione.

--- a/src/directus/translations/it-IT/projects.submit.error.sectors_too_many.it-IT.yaml
+++ b/src/directus/translations/it-IT/projects.submit.error.sectors_too_many.it-IT.yaml
@@ -1,0 +1,3 @@
+language: it-IT
+key: projects.submit.error.sectors_too_many
+value: "Seleziona al massimo :max settori."

--- a/src/directus/translations/it-IT/projects.submit.error.service_unavailable.it-IT.yaml
+++ b/src/directus/translations/it-IT/projects.submit.error.service_unavailable.it-IT.yaml
@@ -1,0 +1,3 @@
+language: it-IT
+key: projects.submit.error.service_unavailable
+value: Al momento non è possibile inviare il modulo. Riprova più tardi.

--- a/src/directus/translations/it-IT/projects.submit.error.state_invalid.it-IT.yaml
+++ b/src/directus/translations/it-IT/projects.submit.error.state_invalid.it-IT.yaml
@@ -1,0 +1,3 @@
+language: it-IT
+key: projects.submit.error.state_invalid
+value: Seleziona uno stato federale valido.

--- a/src/directus/translations/it-IT/projects.submit.error.submission_too_large.it-IT.yaml
+++ b/src/directus/translations/it-IT/projects.submit.error.submission_too_large.it-IT.yaml
@@ -1,0 +1,3 @@
+language: it-IT
+key: projects.submit.error.submission_too_large
+value: L'intero invio è troppo grande. Seleziona un'immagine più piccola.

--- a/src/directus/translations/it-IT/projects.submit.error.url_invalid.it-IT.yaml
+++ b/src/directus/translations/it-IT/projects.submit.error.url_invalid.it-IT.yaml
@@ -1,0 +1,3 @@
+language: it-IT
+key: projects.submit.error.url_invalid
+value: "Inserisci un URL valido per :field."

--- a/src/directus/translations/it-IT/projects.submit.hint.image.it-IT.yaml
+++ b/src/directus/translations/it-IT/projects.submit.hint.image.it-IT.yaml
@@ -1,0 +1,3 @@
+language: it-IT
+key: projects.submit.hint.image
+value: "JPG, PNG o WebP, fino a :max MB."

--- a/src/directus/translations/it-IT/projects.submit.hint.sectors_max.it-IT.yaml
+++ b/src/directus/translations/it-IT/projects.submit.hint.sectors_max.it-IT.yaml
@@ -1,0 +1,3 @@
+language: it-IT
+key: projects.submit.hint.sectors_max
+value: "Puoi selezionare fino a :max settori."

--- a/src/frontend/.env.example
+++ b/src/frontend/.env.example
@@ -29,6 +29,7 @@ WELCOME_EMAIL_CALENDAR_URL=
 WELCOME_EMAIL_SIGNAL_URL=
 
 ALTCHA_SECRET=dev-secret-change-in-production
+# Server-only token of an active Directus Administrator. Never reuse the public DIRECTUS_TOKEN.
 DIRECTUS_ADMIN_TOKEN=
 
 # Directus flow webhook URLs for sending emails (set after importing flows)

--- a/src/frontend/pages/projects/submit.vue
+++ b/src/frontend/pages/projects/submit.vue
@@ -28,7 +28,7 @@
             id="project-title"
             v-model="form.title"
             type="text"
-            maxlength="180"
+            :maxlength="ARTICLE_SUBMISSION_LIMITS.title"
             required
             class="input input-bordered w-full"
           />
@@ -42,7 +42,7 @@
             id="project-subtitle"
             v-model="form.subtitle"
             type="text"
-            maxlength="255"
+            :maxlength="ARTICLE_SUBMISSION_LIMITS.subtitle"
             class="input input-bordered w-full"
           />
         </div>
@@ -56,7 +56,7 @@
               id="project-municipality"
               v-model="form.municipalityName"
               type="text"
-              maxlength="120"
+              :maxlength="ARTICLE_SUBMISSION_LIMITS.municipalityName"
               required
               class="input input-bordered w-full"
             />
@@ -84,10 +84,20 @@
                 type="checkbox"
                 class="border-gray-300 checkbox checkbox-sm"
                 :value="sector.value"
+                :disabled="
+                  !form.sectors.includes(sector.value) && form.sectors.length >= ARTICLE_SUBMISSION_MAX_SECTORS
+                "
               />
               <span>{{ sector.label }}</span>
             </label>
           </div>
+          <p class="text-gray-500 mt-2 text-xs">
+            {{
+              $t("projects.submit.hint.sectors_max", {
+                ":max": ARTICLE_SUBMISSION_MAX_SECTORS,
+              })
+            }}
+          </p>
         </fieldset>
 
         <div>
@@ -98,10 +108,13 @@
             id="project-abstract"
             v-model="form.abstract"
             rows="4"
-            maxlength="1500"
+            :maxlength="ARTICLE_SUBMISSION_LIMITS.abstract"
             required
             class="textarea textarea-bordered w-full"
           />
+          <p class="text-gray-500 mt-1 text-right text-xs">
+            {{ form.abstract.length }} / {{ ARTICLE_SUBMISSION_LIMITS.abstract }}
+          </p>
         </div>
 
         <div>
@@ -112,10 +125,13 @@
             id="project-article-text"
             v-model="form.articleText"
             rows="9"
-            maxlength="10000"
+            :maxlength="ARTICLE_SUBMISSION_LIMITS.articleText"
             required
             class="textarea textarea-bordered w-full"
           />
+          <p class="text-gray-500 mt-1 text-right text-xs">
+            {{ form.articleText.length }} / {{ ARTICLE_SUBMISSION_LIMITS.articleText }}
+          </p>
         </div>
 
         <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
@@ -127,7 +143,7 @@
               id="project-link"
               v-model="form.link"
               type="url"
-              maxlength="255"
+              :maxlength="ARTICLE_SUBMISSION_LIMITS.link"
               class="input input-bordered w-full"
             />
           </div>
@@ -139,7 +155,7 @@
               id="project-instagram"
               v-model="form.instagram"
               type="url"
-              maxlength="255"
+              :maxlength="ARTICLE_SUBMISSION_LIMITS.instagram"
               class="input input-bordered w-full"
             />
           </div>
@@ -151,7 +167,7 @@
               id="project-linkedin"
               v-model="form.linkedin"
               type="url"
-              maxlength="255"
+              :maxlength="ARTICLE_SUBMISSION_LIMITS.linkedin"
               class="input input-bordered w-full"
             />
           </div>
@@ -166,11 +182,14 @@
               id="project-image"
               ref="imageInputRef"
               type="file"
-              accept="image/jpeg,image/png,image/webp"
+              :accept="ALLOWED_IMAGE_TYPES.join(',')"
               required
               class="file-input file-input-bordered w-full"
               @change="onImageChange"
             />
+            <p class="text-gray-500 mt-1 text-xs">
+              {{ $t("projects.submit.hint.image", { ":max": ARTICLE_SUBMISSION_MAX_IMAGE_MB }) }}
+            </p>
           </div>
 
           <div>
@@ -181,7 +200,7 @@
               id="project-image-credits"
               v-model="form.imageCredits"
               type="text"
-              maxlength="255"
+              :maxlength="ARTICLE_SUBMISSION_LIMITS.imageCredits"
               required
               class="input input-bordered w-full"
             />
@@ -214,7 +233,7 @@
               v-model="form.author"
               type="text"
               autocomplete="name"
-              maxlength="120"
+              :maxlength="ARTICLE_SUBMISSION_LIMITS.author"
               required
               class="input input-bordered w-full"
             />
@@ -229,7 +248,7 @@
               v-model="form.submitterEmail"
               type="email"
               autocomplete="email"
-              maxlength="255"
+              :maxlength="ARTICLE_SUBMISSION_LIMITS.submitterEmail"
               required
               class="input input-bordered w-full"
             />
@@ -257,7 +276,9 @@
           <p v-if="captchaError" class="text-red-500 mt-1 text-xs">{{ captchaError }}</p>
         </div>
 
-        <p v-if="errorMessage" class="text-red-600 text-sm">{{ errorMessage }}</p>
+        <div v-if="errorMessage" role="alert" class="alert alert-error text-sm">
+          <span>{{ errorMessage }}</span>
+        </div>
 
         <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <p class="text-gray-400 text-xs">{{ $t("generic.privacy.disclaimer") }}</p>
@@ -276,6 +297,15 @@
 </template>
 
 <script setup lang="ts">
+import {
+  ARTICLE_SUBMISSION_LIMITS,
+  ARTICLE_SUBMISSION_MAX_IMAGE_BYTES,
+  ARTICLE_SUBMISSION_MAX_SECTORS,
+  type ArticleSubmissionErrorCode,
+  type ArticleSubmissionErrorData,
+  type ArticleSubmissionTextField,
+} from "~/shared/articleSubmission";
+
 type ArticleSubmissionForm = {
   title: string;
   subtitle: string;
@@ -296,6 +326,46 @@ type ArticleSubmissionForm = {
 const { $t, $locale } = useNuxtApp();
 
 useHead({ title: $t("projects.submit.title") });
+
+const ALLOWED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp"];
+const ARTICLE_SUBMISSION_MAX_IMAGE_MB = ARTICLE_SUBMISSION_MAX_IMAGE_BYTES / 1024 / 1024;
+
+const fieldTranslationKeys: Record<ArticleSubmissionTextField, string> = {
+  title: "projects.submit.field.title",
+  subtitle: "projects.submit.field.subtitle",
+  municipalityName: "projects.submit.field.municipality",
+  state: "projects.submit.field.state",
+  abstract: "projects.submit.field.abstract",
+  articleText: "projects.submit.field.article_text",
+  link: "projects.submit.field.link",
+  instagram: "projects.submit.field.instagram",
+  linkedin: "projects.submit.field.linkedin",
+  imageCredits: "projects.submit.field.image_credits",
+  author: "projects.submit.field.author",
+  submitterEmail: "projects.submit.field.email",
+};
+
+const errorTranslationKeys: Record<ArticleSubmissionErrorCode, string> = {
+  captcha_failed: "projects.submit.error.captcha_failed",
+  email_invalid: "projects.submit.error.email_invalid",
+  field_too_long: "projects.submit.error.field_too_long",
+  image_format: "projects.submit.error.image_format",
+  image_invalid: "projects.submit.error.image_invalid",
+  image_required: "projects.submit.error.image_required",
+  image_rights_required: "projects.submit.error.image_rights_required",
+  image_too_large: "projects.submit.error.image_too_large",
+  invalid_submission: "projects.submit.error.invalid_submission",
+  required_fields: "projects.submit.error.required_fields",
+  save_failed: "projects.submit.error.save_failed",
+  sectors_invalid: "projects.submit.error.sectors_invalid",
+  sectors_required: "projects.submit.error.sectors_required",
+  sectors_too_many: "projects.submit.error.sectors_too_many",
+  service_unavailable: "projects.submit.error.service_unavailable",
+  state_invalid: "projects.submit.error.state_invalid",
+  submission_too_large: "projects.submit.error.submission_too_large",
+  url_invalid: "projects.submit.error.url_invalid",
+  url_too_long: "projects.submit.error.field_too_long",
+};
 
 const stateOptions = [
   "Baden-Württemberg",
@@ -402,7 +472,23 @@ onUnmounted(() => {
 
 function onImageChange(event: Event) {
   const input = event.target as HTMLInputElement;
-  selectedImage.value = input.files?.[0] ?? null;
+  const image = input.files?.[0] ?? null;
+  errorMessage.value = "";
+  if (image && !ALLOWED_IMAGE_TYPES.includes(image.type)) {
+    selectedImage.value = null;
+    input.value = "";
+    errorMessage.value = $t("projects.submit.error.image_format");
+    return;
+  }
+  if (image && image.size > ARTICLE_SUBMISSION_MAX_IMAGE_BYTES) {
+    selectedImage.value = null;
+    input.value = "";
+    errorMessage.value = $t("projects.submit.error.image_too_large", {
+      ":max": ARTICLE_SUBMISSION_MAX_IMAGE_MB,
+    });
+    return;
+  }
+  selectedImage.value = image;
 }
 
 function resetForm() {
@@ -416,10 +502,46 @@ function resetForm() {
   }
 }
 
+function translateSubmissionError(data: ArticleSubmissionErrorData) {
+  const translationKey = errorTranslationKeys[data.errorCode];
+  const field = data.field ? $t(fieldTranslationKeys[data.field]) : "";
+  return $t(translationKey, {
+    ":field": field,
+    ":max": data.maxLength ?? data.maxSectors ?? data.maxSizeMb ?? "",
+  });
+}
+
+function getSubmissionErrorMessage(err: any) {
+  const data = (err?.data?.error ?? err?.data?.data) as ArticleSubmissionErrorData | undefined;
+  if (data?.errorCode && errorTranslationKeys[data.errorCode]) {
+    return translateSubmissionError(data);
+  }
+  const publicMessage = err?.data?.message;
+  if (publicMessage && publicMessage !== "Server Error") {
+    return publicMessage;
+  }
+  return $t("generic.technical_error");
+}
+
+function validateTextLengths() {
+  for (const [field, maxLength] of Object.entries(ARTICLE_SUBMISSION_LIMITS) as Array<
+    [ArticleSubmissionTextField, number]
+  >) {
+    if (form[field].length > maxLength) {
+      errorMessage.value = translateSubmissionError({ errorCode: "field_too_long", field, maxLength });
+      return false;
+    }
+  }
+  return true;
+}
+
 async function submitArticle() {
   errorMessage.value = "";
   captchaError.value = "";
 
+  if (!validateTextLengths()) {
+    return;
+  }
   const payload = altchaPayload.value || altchaRef.value?.value;
   if (!payload) {
     captchaError.value = $t("captcha.required");
@@ -435,6 +557,12 @@ async function submitArticle() {
   }
   if (form.sectors.length === 0) {
     errorMessage.value = $t("projects.submit.error.sectors_required");
+    return;
+  }
+  if (form.sectors.length > ARTICLE_SUBMISSION_MAX_SECTORS) {
+    errorMessage.value = $t("projects.submit.error.sectors_too_many", {
+      ":max": ARTICLE_SUBMISSION_MAX_SECTORS,
+    });
     return;
   }
 
@@ -467,7 +595,7 @@ async function submitArticle() {
       resetForm();
     }
   } catch (err: any) {
-    errorMessage.value = err?.data?.message ?? $t("generic.technical_error");
+    errorMessage.value = getSubmissionErrorMessage(err);
   } finally {
     loading.value = false;
   }

--- a/src/frontend/server/api/submit-article.post.ts
+++ b/src/frontend/server/api/submit-article.post.ts
@@ -1,11 +1,18 @@
 import { randomBytes } from "node:crypto";
 import type { H3Event } from "h3";
+import {
+  ARTICLE_SUBMISSION_LIMITS,
+  ARTICLE_SUBMISSION_MAX_IMAGE_BYTES,
+  ARTICLE_SUBMISSION_MAX_MULTIPART_BYTES,
+  ARTICLE_SUBMISSION_MAX_SECTORS,
+  type ArticleSubmissionErrorCode,
+  type ArticleSubmissionErrorData,
+  type ArticleSubmissionTextField,
+} from "~/shared/articleSubmission";
 import { createSlug } from "~/shared/slugify.js";
 import { verifyAltcha } from "../utils/verifyAltcha";
 
 const ARTICLE_IMAGE_FOLDER_ID = "82d3f1c5-9a8d-4aeb-8335-ca9330a43b90";
-const MAX_MULTIPART_BYTES = 7 * 1024 * 1024;
-const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
 const ALLOWED_IMAGE_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
 const ALLOWED_STATES = new Set([
   "Baden-Württemberg",
@@ -77,18 +84,50 @@ type ArticlePayload = {
 
 type NotificationValue = string | string[] | null | undefined;
 
-function submissionError(statusCode: number, message: string) {
-  return createError({ statusCode, message });
+function submissionStatusMessage(statusCode: number) {
+  if (statusCode === 400) return "Invalid submission";
+  if (statusCode === 413) return "Submission too large";
+  if (statusCode === 503) return "Submission service unavailable";
+  return "Submission failed";
 }
 
-function getTextField(parts: MultipartPart[], name: string, maxLength: number, required = false) {
+function submissionError(
+  statusCode: number,
+  errorCode: ArticleSubmissionErrorCode,
+  message: string,
+  details: Omit<ArticleSubmissionErrorData, "errorCode"> = {},
+) {
+  return createError({
+    statusCode,
+    statusMessage: submissionStatusMessage(statusCode),
+    message,
+    data: { errorCode, ...details } satisfies ArticleSubmissionErrorData,
+  });
+}
+
+function getTextField(parts: MultipartPart[], name: ArticleSubmissionTextField, required = false) {
   const part = parts.find((item) => item.name === name && !item.filename);
-  const value = part?.data.toString("utf8").replace(/\0/g, "").trim() ?? "";
+  // Browsers normalize textarea values to LF for maxlength checks, but multipart
+  // encoding converts line endings to CRLF. Normalize them back before measuring.
+  const value = part?.data.toString("utf8").replace(/\0/g, "").replace(/\r\n?/g, "\n").trim() ?? "";
   if (required && !value) {
-    throw submissionError(400, "Bitte alle Pflichtfelder ausfüllen.");
+    throw submissionError(400, "required_fields", "Bitte alle Pflichtfelder ausfüllen.");
+  }
+  const maxLength = ARTICLE_SUBMISSION_LIMITS[name];
+  if (value.length > maxLength) {
+    throw submissionError(400, "field_too_long", `${name} ist zu lang.`, { field: name, maxLength });
+  }
+  return value;
+}
+
+function getInternalTextField(parts: MultipartPart[], name: string, maxLength: number, required = false) {
+  const part = parts.find((item) => item.name === name && !item.filename);
+  const value = part?.data.toString("utf8").replace(/\0/g, "").replace(/\r\n?/g, "\n").trim() ?? "";
+  if (required && !value) {
+    throw submissionError(400, "required_fields", "Bitte alle Pflichtfelder ausfüllen.");
   }
   if (value.length > maxLength) {
-    throw submissionError(400, "Ein Feld ist zu lang.");
+    throw submissionError(400, "invalid_submission", `${name} ist zu lang.`);
   }
   return value;
 }
@@ -102,36 +141,42 @@ function parseSectors(rawValue: string) {
   try {
     values = JSON.parse(rawValue);
   } catch {
-    throw submissionError(400, "Ungültige Sektoren.");
+    throw submissionError(400, "sectors_invalid", "Ungültige Sektoren.");
   }
   if (!Array.isArray(values) || values.length === 0) {
-    throw submissionError(400, "Bitte mindestens einen Sektor auswählen.");
+    throw submissionError(400, "sectors_required", "Bitte mindestens einen Sektor auswählen.");
   }
   const sectors = values.map((value) => String(value));
-  if (sectors.length > 5 || sectors.some((value) => !ALLOWED_SECTORS.has(value))) {
-    throw submissionError(400, "Ungültige Sektoren.");
+  if (sectors.length > ARTICLE_SUBMISSION_MAX_SECTORS) {
+    throw submissionError(400, "sectors_too_many", "Zu viele Sektoren ausgewählt.", {
+      maxSectors: ARTICLE_SUBMISSION_MAX_SECTORS,
+    });
+  }
+  if (sectors.some((value) => !ALLOWED_SECTORS.has(value))) {
+    throw submissionError(400, "sectors_invalid", "Ungültige Sektoren.");
   }
   return sectors;
 }
 
-function normalizeOptionalUrl(value: string, fieldLabel: string, hostnamePattern?: RegExp) {
+function normalizeOptionalUrl(value: string, field: "link" | "instagram" | "linkedin", hostnamePattern?: RegExp) {
   if (!value) return null;
   const candidate = /^https?:\/\//i.test(value) ? value : `https://${value}`;
   let url: URL;
   try {
     url = new URL(candidate);
   } catch {
-    throw submissionError(400, `${fieldLabel} ist keine gültige URL.`);
+    throw submissionError(400, "url_invalid", `${field} ist keine gültige URL.`, { field });
   }
   if (!["http:", "https:"].includes(url.protocol)) {
-    throw submissionError(400, `${fieldLabel} ist keine gültige URL.`);
+    throw submissionError(400, "url_invalid", `${field} ist keine gültige URL.`, { field });
   }
   if (hostnamePattern && !hostnamePattern.test(url.hostname)) {
-    throw submissionError(400, `${fieldLabel} ist keine gültige URL.`);
+    throw submissionError(400, "url_invalid", `${field} ist keine gültige URL.`, { field });
   }
   const normalized = url.toString();
-  if (normalized.length > 255) {
-    throw submissionError(400, `${fieldLabel} ist zu lang.`);
+  const maxLength = ARTICLE_SUBMISSION_LIMITS[field];
+  if (normalized.length > maxLength) {
+    throw submissionError(400, "url_too_long", `${field} ist zu lang.`, { field, maxLength });
   }
   return normalized;
 }
@@ -167,13 +212,15 @@ function hasValidImageSignature(part: MultipartPart) {
 
 function validateImage(part: MultipartPart) {
   if (!part.type || !ALLOWED_IMAGE_TYPES.has(part.type)) {
-    throw submissionError(400, "Bitte ein Bild im Format JPG, PNG oder WebP hochladen.");
+    throw submissionError(400, "image_format", "Bitte ein Bild im Format JPG, PNG oder WebP hochladen.");
   }
-  if (part.data.length > MAX_IMAGE_BYTES) {
-    throw submissionError(413, "Das Bild ist zu groß.");
+  if (part.data.length > ARTICLE_SUBMISSION_MAX_IMAGE_BYTES) {
+    throw submissionError(413, "image_too_large", "Das Bild ist zu groß.", {
+      maxSizeMb: ARTICLE_SUBMISSION_MAX_IMAGE_BYTES / 1024 / 1024,
+    });
   }
   if (!hasValidImageSignature(part)) {
-    throw submissionError(400, "Die Bilddatei konnte nicht validiert werden.");
+    throw submissionError(400, "image_invalid", "Die Bilddatei konnte nicht validiert werden.");
   }
 }
 
@@ -263,7 +310,7 @@ async function readMultipartParts(event: H3Event) {
     /boundary=(?:"([^"]+)"|([^;]+))/i.exec(contentType)?.[1] ??
     /boundary=(?:"([^"]+)"|([^;]+))/i.exec(contentType)?.[2];
   if (!boundary) {
-    throw submissionError(400, "Ungültige Einreichung.");
+    throw submissionError(400, "invalid_submission", "Ungültige Einreichung.");
   }
 
   const body = await readRequestBuffer(event);
@@ -314,56 +361,56 @@ async function readMultipartParts(event: H3Event) {
   return parts;
 }
 
-export default defineEventHandler(async (event) => {
+async function submitArticle(event: H3Event) {
   const contentLength = getContentLength(event);
-  if (contentLength > MAX_MULTIPART_BYTES) {
-    throw submissionError(413, "Die Einreichung ist zu groß.");
+  if (contentLength > ARTICLE_SUBMISSION_MAX_MULTIPART_BYTES) {
+    throw submissionError(413, "submission_too_large", "Die Einreichung ist zu groß.");
   }
 
   const parts = await readMultipartParts(event);
   if (!parts?.length) {
-    throw submissionError(400, "Ungültige Einreichung.");
+    throw submissionError(400, "invalid_submission", "Ungültige Einreichung.");
   }
 
   const config = useRuntimeConfig();
   const hmacKey = (config.altchaSecret as string) || "dev-secret-change-in-production";
-  const altcha = getTextField(parts, "altcha", 4096, true);
+  const altcha = getInternalTextField(parts, "altcha", 4096, true);
 
   if (!verifyAltcha(altcha, hmacKey)) {
-    throw submissionError(400, "CAPTCHA-Überprüfung fehlgeschlagen. Bitte Seite neu laden und es erneut versuchen.");
+    throw submissionError(
+      400,
+      "captcha_failed",
+      "CAPTCHA-Überprüfung fehlgeschlagen. Bitte Seite neu laden und es erneut versuchen.",
+    );
   }
 
-  const title = getTextField(parts, "title", 180, true);
-  const subtitle = getTextField(parts, "subtitle", 255);
-  const author = getTextField(parts, "author", 120, true);
-  const submitterEmail = getTextField(parts, "submitterEmail", 255, true).toLowerCase();
-  const municipalityName = getTextField(parts, "municipalityName", 120, true);
-  const state = getTextField(parts, "state", 80);
-  const abstract = getTextField(parts, "abstract", 1500, true);
-  const articleText = getTextField(parts, "articleText", 10000, true);
-  const imageCredits = getTextField(parts, "imageCredits", 255, true);
-  const imageRightsConfirmed = getTextField(parts, "imageRightsConfirmed", 10) === "true";
-  const sectors = parseSectors(getTextField(parts, "sectors", 1000, true));
-  const link = normalizeOptionalUrl(getTextField(parts, "link", 255), "Projektlink");
-  const instagram = normalizeOptionalUrl(
-    getTextField(parts, "instagram", 255),
-    "Instagram-Link",
-    /(^|\.)instagram\.com$/i,
-  );
-  const linkedin = normalizeOptionalUrl(getTextField(parts, "linkedin", 255), "LinkedIn-Link", /(^|\.)linkedin\.com$/i);
+  const title = getTextField(parts, "title", true);
+  const subtitle = getTextField(parts, "subtitle");
+  const author = getTextField(parts, "author", true);
+  const submitterEmail = getTextField(parts, "submitterEmail", true).toLowerCase();
+  const municipalityName = getTextField(parts, "municipalityName", true);
+  const state = getTextField(parts, "state");
+  const abstract = getTextField(parts, "abstract", true);
+  const articleText = getTextField(parts, "articleText", true);
+  const imageCredits = getTextField(parts, "imageCredits", true);
+  const imageRightsConfirmed = getInternalTextField(parts, "imageRightsConfirmed", 10) === "true";
+  const sectors = parseSectors(getInternalTextField(parts, "sectors", 1000, true));
+  const link = normalizeOptionalUrl(getTextField(parts, "link"), "link");
+  const instagram = normalizeOptionalUrl(getTextField(parts, "instagram"), "instagram", /(^|\.)instagram\.com$/i);
+  const linkedin = normalizeOptionalUrl(getTextField(parts, "linkedin"), "linkedin", /(^|\.)linkedin\.com$/i);
   const image = getImagePart(parts);
 
   if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(submitterEmail)) {
-    throw submissionError(400, "Ungültige E-Mail-Adresse.");
+    throw submissionError(400, "email_invalid", "Ungültige E-Mail-Adresse.", { field: "submitterEmail" });
   }
   if (state && !ALLOWED_STATES.has(state)) {
-    throw submissionError(400, "Ungültiges Bundesland.");
+    throw submissionError(400, "state_invalid", "Ungültiges Bundesland.", { field: "state" });
   }
   if (!image) {
-    throw submissionError(400, "Bitte ein Bild hochladen.");
+    throw submissionError(400, "image_required", "Bitte ein Bild hochladen.");
   }
   if (!imageRightsConfirmed) {
-    throw submissionError(400, "Bitte bestätige die Bildrechte und den Bildnachweis.");
+    throw submissionError(400, "image_rights_required", "Bitte bestätige die Bildrechte und den Bildnachweis.");
   }
   validateImage(image);
 
@@ -371,7 +418,19 @@ export default defineEventHandler(async (event) => {
   const adminToken = config.directusAdminToken as string | undefined;
   if (!adminToken) {
     console.error("[submit-article] DIRECTUS_ADMIN_TOKEN not configured");
-    throw submissionError(503, "Einreichung kann momentan nicht gespeichert werden. Bitte versuche es später erneut.");
+    throw submissionError(
+      503,
+      "service_unavailable",
+      "Einreichung kann momentan nicht gespeichert werden. Bitte versuche es später erneut.",
+    );
+  }
+  if (adminToken === config.public.directusToken) {
+    console.error("[submit-article] DIRECTUS_ADMIN_TOKEN must not be the public frontend token");
+    throw submissionError(
+      503,
+      "service_unavailable",
+      "Einreichung kann momentan nicht gespeichert werden. Bitte versuche es später erneut.",
+    );
   }
 
   const headers = { Authorization: `Bearer ${adminToken}` };
@@ -468,13 +527,50 @@ export default defineEventHandler(async (event) => {
     }
 
     return { success: true, id: article.data.id, status: article.data.status };
-  } catch (err) {
+  } catch (err: any) {
     if (imageId) {
       await $fetch(`${directusUrl}/files/${imageId}`, { method: "DELETE", headers }).catch((cleanupErr) => {
         console.warn("[submit-article] Failed to clean up uploaded image after article error:", cleanupErr);
       });
     }
-    console.error("[submit-article] Directus error:", err);
-    throw submissionError(502, "Einreichung konnte nicht gespeichert werden. Bitte versuche es später erneut.");
+    const directusError = err?.data?.errors?.[0];
+    const directusCode = directusError?.extensions?.code;
+    const directusStatus = err?.statusCode ?? err?.response?.status;
+    console.error("[submit-article] Directus error:", {
+      status: directusStatus,
+      code: directusCode,
+      message: directusError?.message ?? err?.message,
+    });
+    if (directusStatus === 401 || directusStatus === 403 || directusCode === "FORBIDDEN") {
+      console.error("[submit-article] DIRECTUS_ADMIN_TOKEN lacks permission to create articles or files");
+      throw submissionError(
+        503,
+        "service_unavailable",
+        "Einreichung kann momentan nicht gespeichert werden. Bitte versuche es später erneut.",
+      );
+    }
+    throw submissionError(
+      502,
+      "save_failed",
+      "Einreichung konnte nicht gespeichert werden. Bitte versuche es später erneut.",
+    );
+  }
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    return await submitArticle(event);
+  } catch (err: any) {
+    const errorData = err?.data as ArticleSubmissionErrorData | undefined;
+    if (errorData?.errorCode) {
+      const statusCode = Number(err.statusCode) || 500;
+      event.node.res.statusCode = statusCode;
+      event.node.res.statusMessage = err.statusMessage || submissionStatusMessage(statusCode);
+      return {
+        success: false,
+        error: errorData,
+      };
+    }
+    throw err;
   }
 });

--- a/src/frontend/shared/articleSubmission.ts
+++ b/src/frontend/shared/articleSubmission.ts
@@ -1,0 +1,49 @@
+export const ARTICLE_SUBMISSION_LIMITS = {
+  title: 180,
+  subtitle: 255,
+  municipalityName: 120,
+  state: 80,
+  abstract: 1_500,
+  articleText: 10_000,
+  link: 255,
+  instagram: 255,
+  linkedin: 255,
+  imageCredits: 255,
+  author: 120,
+  submitterEmail: 255,
+} as const;
+
+export const ARTICLE_SUBMISSION_MAX_SECTORS = 5;
+export const ARTICLE_SUBMISSION_MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+export const ARTICLE_SUBMISSION_MAX_MULTIPART_BYTES = 7 * 1024 * 1024;
+
+export type ArticleSubmissionTextField = keyof typeof ARTICLE_SUBMISSION_LIMITS;
+
+export type ArticleSubmissionErrorCode =
+  | "captcha_failed"
+  | "email_invalid"
+  | "field_too_long"
+  | "image_format"
+  | "image_invalid"
+  | "image_required"
+  | "image_rights_required"
+  | "image_too_large"
+  | "invalid_submission"
+  | "required_fields"
+  | "save_failed"
+  | "sectors_invalid"
+  | "sectors_required"
+  | "sectors_too_many"
+  | "service_unavailable"
+  | "state_invalid"
+  | "submission_too_large"
+  | "url_invalid"
+  | "url_too_long";
+
+export type ArticleSubmissionErrorData = {
+  errorCode: ArticleSubmissionErrorCode;
+  field?: ArticleSubmissionTextField;
+  maxLength?: number;
+  maxSectors?: number;
+  maxSizeMb?: number;
+};


### PR DESCRIPTION
  Root causes:

  - The logged failure was the abstract field. Browser maxlength counts newlines
    as \n, while multipart encoding sends \r\n, making a valid 1,500-character
    textarea appear too long server-side.

  - Production Nitro sanitizes thrown validation errors, replacing their
    messages with “Server Error.”

  - The API allowed at most five sectors and 5 MB images, but the frontend did
    not enforce those limits.

  - Directus writes use DIRECTUS_ADMIN_TOKEN; frontend/public permissions are
    unrelated. A 403 therefore indicates a missing, swapped, or underprivileged
    server token.

 Changes:

  - Centralized all limits in src/frontend/shared/articleSubmission.ts.
  - Normalized newlines before server-side length checks.
  - Added explicit HTTP error bodies with stable error codes and field/max
    details.

  - Added translated errors and hints for German, English, and Italian.
  - Enforced sector count, image type/size, and text lengths in src/frontend/
    pages/projects/submit.vue.

  - Improved Directus permission diagnostics in src/frontend/server/api/submit-
    article.post.ts.

  - Documented that DIRECTUS_ADMIN_TOKEN must belong to an active Administrator
    and must not equal the public frontend token.
