### PR TITLE
Fix Localteam Registrierung Bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ## Project overview
 
 Nuxt 3 frontend + Directus CMS backend, running in Docker Compose.
-
+Code language and variables always favour english language.
 ---
 
 ## Directus schema & permissions workflow

--- a/REGISTER_LOCALTEAM_STATUSLOGIK.md
+++ b/REGISTER_LOCALTEAM_STATUSLOGIK.md
@@ -1,0 +1,168 @@
+# Lokalteam gründen: Kommunenauswahl und Bewertungsstatus
+
+## Zusammenfassung
+
+Das Formular unter `/register_localteam` vermischte bisher nicht bewertbare
+Verwaltungsebenen mit Kommunen und leitete den Lokalteam- beziehungsweise
+Bewertungsstatus aus mehreren uneinheitlichen Quellen ab. Dadurch konnten unter
+anderem Bundesländer und Regierungsbezirke in der Kommunenauswahl erscheinen,
+vorhandene oder fehlende Lokalteams falsch erkannt und unveröffentlichte
+Bewertungen als abgeschlossen angezeigt werden.
+
+Die Statuslogik verwendet nun ausschließlich die als `isCurrentBackend: true`
+markierte Version des Maßnahmenkatalogs. Eine Bewertung gilt genau dann als
+abgeschlossen, wenn der zugehörige Datensatz in dieser Katalogversion
+veröffentlicht ist.
+
+## Ursachen des vorherigen Verhaltens
+
+### Gemischte Verwaltungsebenen in der Suche
+
+Das Formular verwendete den Suchmodus `normal`. Dieser Modus liefert sowohl
+Verwaltungsebenen 1 bis 3 als auch bewertbare Kommunen. Deshalb wurden neben
+Gemeinden und Städten beispielsweise Bundesländer und Regierungsbezirke
+angezeigt.
+
+### Katalogunabhängige Bewertungsermittlung
+
+Der Bewertungsstatus wurde teilweise aus externen StadtLandZahl-Daten, globalen
+Listen veröffentlichter Slugs oder dem höchsten beziehungsweise ersten
+gefundenen Bewertungsfortschritt abgeleitet. Diese Daten mussten nicht zur
+aktuellen Backend-Version des Maßnahmenkatalogs gehören.
+
+### Prozentwert als Abschlusskriterium
+
+Ein Bewertungsfortschritt ab 98 Prozent wurde als abgeschlossen behandelt. Das
+Feld `published` wurde dabei nicht zuverlässig berücksichtigt. Somit konnte eine
+unveröffentlichte Bewertung als fertig erscheinen, während eine veröffentlichte
+Bewertung unterhalb des Grenzwerts weiterhin als in Arbeit galt.
+
+### Slug als Ersatz für die Teamexistenz
+
+Die Existenz eines Lokalteams wurde teilweise über einen vorhandenen Slug
+abgeleitet. Das führte in beide Richtungen zu Fehlern:
+
+- Ein Slug aus der URL oder aus externen Bewertungsdaten konnte ein nicht
+  vorhandenes Lokalteam vortäuschen.
+- Ein vorhandenes Lokalteam ohne Municipality-Slug konnte als nicht existent
+  behandelt werden.
+
+Insbesondere ein veralteter oder manipulierter `slug`-Query-Parameter konnte das
+Gründungsformular fälschlich durch den Hinweis auf ein bestehendes Team ersetzen.
+
+### Kein eigener Zustand für null Prozent
+
+Ein vorhandenes Lokalteam mit fehlendem Bewertungsdatensatz oder null Prozent
+Fortschritt wurde genauso dargestellt wie eine tatsächlich begonnene Bewertung.
+
+## Neue fachliche Regeln
+
+Die Seite lädt genau eine sichtbare Katalogversion mit
+`isCurrentBackend: true`. Ist die Directus-Konfiguration nicht eindeutig, wird
+ein Fehler ausgelöst, statt stillschweigend eine beliebige Version zu verwenden.
+
+Der Formularstatus wird anschließend nach folgender Reihenfolge bestimmt:
+
+| Voraussetzung | Status | Darstellung und Aktion |
+|---|---|---|
+| Kein `localteam_id` vorhanden | `none` | Gründungsformular beziehungsweise „Jetzt Lokalteam gründen“ |
+| Lokalteam vorhanden und Bewertung der aktuellen Version veröffentlicht | `complete` | „Bewertung abgeschlossen“, Bewertungslink soweit ein Slug vorhanden ist, zusätzlich Kontaktmöglichkeit |
+| Lokalteam vorhanden, aktuelle Bewertung unveröffentlicht und Fortschritt größer als 0 Prozent | `in-progress` | „Lokalteam aktiv – Bewertung läuft“ und Kontaktmöglichkeit |
+| Lokalteam vorhanden, aktuelle Bewertung fehlt oder steht bei 0 Prozent | `not-started` | „Lokalteam aktiv – Bewertung noch nicht begonnen“ und Kontaktmöglichkeit |
+
+`published: true` hat Vorrang vor dem Prozentwert. Damit gilt auch eine
+veröffentlichte Bewertung mit einem ungewöhnlich niedrigen Prozentwert als
+abgeschlossen. Umgekehrt bleibt eine unveröffentlichte Bewertung selbst bei 98
+oder 100 Prozent in Arbeit.
+
+Bewertungen älterer oder zukünftiger Katalogversionen beeinflussen keinen dieser
+Zustände.
+
+## Verhalten vorher und jetzt
+
+| Fall | Vorher | Jetzt |
+|---|---|---|
+| Suche nach „Bayern“ | Bundesland und Regierungsbezirke konnten erscheinen | Keine nicht bewertbaren höheren Ebenen |
+| Bewertbarer Stadtstaat | Konnte wegen seiner Verwaltungsebene uneindeutig sein | Bleibt enthalten, wenn `isReasonableForMunicipalRating: true` gesetzt ist |
+| Kommune ohne Lokalteam | Externer oder übergebener Slug konnte ein Team vortäuschen | Gründungsformular wird angezeigt, solange Directus keinen `localteam_id` bestätigt |
+| Lokalteam ohne Slug | Konnte als nicht vorhanden gelten | Wird über `localteam_id` erkannt; nur der Bewertungslink entfällt |
+| Lokalteam ohne Bewertung der aktuellen Version | Beliebige andere Version konnte den Status beeinflussen | „Bewertung noch nicht begonnen“ |
+| Aktuelle Bewertung bei 0 Prozent, unveröffentlicht | „Bewertung läuft“ | „Bewertung noch nicht begonnen“ |
+| Aktuelle Bewertung über 0 Prozent, unveröffentlicht | In Arbeit; ab 98 Prozent teilweise abgeschlossen | Immer „Bewertung läuft“ |
+| Aktuelle Bewertung veröffentlicht | Unter 98 Prozent teilweise noch in Arbeit | Immer „Bewertung abgeschlossen“ |
+| Nur eine ältere Version ist veröffentlicht | Konnte als abgeschlossen erscheinen | Aktuelle Backend-Version bestimmt den Status |
+| Veralteter oder manipulierter URL-Slug | Konnte ein bestehendes Team vortäuschen | Wird nicht als Identitätsnachweis verwendet |
+
+## Kommunenauswahl
+
+Das Formular verwendet nun den Suchmodus `reasonable`. Dieser beschränkt die
+Ergebnisse auf administrative Gebiete, die für eine kommunale Bewertung
+vorgesehen sind.
+
+Stadtstaaten wie Berlin können weiterhin erscheinen, obwohl sie technisch eine
+höhere Verwaltungsebene besitzen. Sie sind gleichzeitig bewertbare Kommunen und
+werden von StadtLandZahl entsprechend mit
+`isReasonableForMunicipalRating: true` gekennzeichnet.
+
+## Erkennung eines bestehenden Lokalteams
+
+Ein Lokalteam gilt nur als vorhanden, wenn ein passender Municipality-Datensatz
+in Directus einen nicht leeren `localteam_id` besitzt.
+
+Zur Zuordnung werden verwendet:
+
+1. Slugs aus dem StadtLandZahl-Suchergebnis beziehungsweise aus der über die ARS
+   geladenen StadtLandZahl-Antwort.
+2. Die amtliche ARS als Fallback.
+
+Ein über die Seiten-URL gelieferter Slug wird bewusst ignoriert. Damit können
+veraltete Links und frei manipulierbare Query-Parameter keine fremde Kommune oder
+kein fremdes Lokalteam zuordnen.
+
+Die Slug-Zuordnung bleibt notwendig, weil ältere durch Directus-Flows erzeugte
+Municipality-Datensätze teilweise keine ARS besitzen.
+
+## Änderungen im Code
+
+- `src/frontend/pages/register_localteam.vue`
+  - verwendet `currentVersionBackend`;
+  - verwendet die eingeschränkte Kommunensuche;
+  - führt die vier expliziten Zustände `none`, `not-started`, `in-progress` und
+    `complete` ein;
+  - prüft die Teamexistenz über `localteam_id`;
+  - ignoriert URL-Slugs als Identitätsnachweis;
+  - liest ausschließlich den Score der aktuellen Backend-Katalogversion.
+- `src/frontend/composables/useAreaSearch.js`
+  - kann Team- und Bewertungsstatus für eine konkrete Directus-Katalogversion
+    anreichern;
+  - unterscheidet in Suchergebnissen zwischen nicht begonnen, in Arbeit,
+    veröffentlicht und ohne Team.
+- `src/frontend/components/AreaSearchResult.vue`
+  - zeigt einen eigenen Chip für „Bewertung noch nicht begonnen“.
+- `src/frontend/composables/getCatalogVersion.js`
+  - stellt eine eindeutige Abfrage für die aktuelle Backend-Katalogversion bereit.
+- `src/directus/translations/{de-DE,en-GB,it-IT}/`
+  - enthält die neuen Texte in Deutsch, Englisch und Italienisch.
+- `bin/test_suite/src/flows/registerLocalteamFlow.ts`
+  - deckt die Kommunensuche, null Prozent, begonnene unveröffentlichte
+    Bewertungen, veröffentlichte Bewertungen und manipulierte URL-Slugs ab.
+
+## Verifikation
+
+Folgende Prüfungen wurden erfolgreich durchgeführt:
+
+- Directus-Übersetzungen über `import-all.sh` importiert;
+- Register-Flow einschließlich Setup und Cleanup: 8 von 8 Schritten erfolgreich;
+- Nuxt-Produktionsbuild erfolgreich;
+- TypeScript-Prüfung erfolgreich;
+- JavaScript-Syntax- und Git-Diff-Prüfungen erfolgreich;
+- `/register_localteam` auf `localhost:8080` antwortet mit HTTP 200;
+- `/api/area-search?term=Bayern&mode=reasonable` liefert keine nicht
+  bewertbaren höheren Verwaltungsebenen.
+
+Der vollständige Lauf von `bin/test_dev.sh` wurde mehrfach gestartet. Er blieb
+in zwei Folgeläufen in einem unveränderten Wahlcheck-Browsertest hängen, bevor
+die Register-Tests erreicht wurden. Dort wurde ein dynamisch erzeugtes
+`question-…`-Eingabefeld nicht innerhalb von 30 Sekunden sichtbar. Derselbe
+Wahlcheck-Schritt war im ersten Lauf erfolgreich. Die separat ausgeführten neuen
+Register-Szenarien sind vollständig grün.

--- a/bin/test_suite/register_localteam_flow/TEST_DESCRIPTION.md
+++ b/bin/test_suite/register_localteam_flow/TEST_DESCRIPTION.md
@@ -30,11 +30,18 @@
 2. Patch that municipality with a valid test ARS.
 3. Open `/register_localteam?ars=<existing-test-ars>&name=<existing-test-municipality>` in a mobile frontend viewport.
 4. Fulfill the optional StadtLandZahl area lookup with deterministic test data for that ARS.
-5. Verify the rendered page detects the existing localteam from Directus and shows `Lokalteam aktiv - Bewertung läuft`.
+5. Verify the rendered page detects the existing localteam from Directus and shows `Lokalteam aktiv – Bewertung noch nicht begonnen` for its 0% current rating.
 6. Verify the selected municipality name is visible.
 7. Verify `Kontakt aufnehmen` is available and links to `/contact` with municipality context.
 8. Verify the new-team registration form and `Lokalteam beantragen` submit button are not shown.
 9. Verify no visible registration error and no browser console/page errors occur.
+
+# Rating Status Cases
+
+1. Verify municipality search uses `mode=reasonable` and therefore excludes non-rateable higher-level regions.
+2. Verify an unpublished current-backend rating above 0% shows `Lokalteam aktiv - Bewertung läuft`.
+3. Verify a published current-backend rating shows `Bewertung abgeschlossen` even when its percentage is 0%.
+4. Verify a stale `slug` URL parameter cannot create an existing-team state for an ARS without a team.
 
 # Ask User To Verify
 

--- a/bin/test_suite/src/flows/registerLocalteamFlow.ts
+++ b/bin/test_suite/src/flows/registerLocalteamFlow.ts
@@ -1,9 +1,6 @@
 import type { Browser, Page } from 'playwright';
 import { assert, assertEqual, assertIncludes, assertNotIncludes } from '../lib/assert.js';
-import {
-  newContext,
-  visibleText,
-} from '../lib/browser.js';
+import { newContext, visibleText } from '../lib/browser.js';
 import type { DirectusClient } from '../lib/directus.js';
 import type { TestFixture } from '../lib/fixture.js';
 import type { TestRunner } from '../lib/runner.js';
@@ -38,6 +35,14 @@ interface Municipality {
   creator_verified?: boolean | null;
   preview_token?: string | null;
   localteam_id?: string | { id: string } | null;
+}
+
+interface MunicipalityScore {
+  id: string;
+  municipality: string | { id: string };
+  catalog_version: string | { id: string; isCurrentBackend?: boolean | null };
+  percentage_rated?: string | number | null;
+  published?: boolean | null;
 }
 
 interface LocalteamUserJunction {
@@ -86,8 +91,8 @@ function watchPageErrors(page: Page, label: string): BrowserErrorCollector {
   });
   page.on('console', (message) => {
     const text = message.text();
-    const isIgnoredDevtoolsSocketError = text.includes('vite_devtools_auth_token')
-      || text.includes('ws://localhost:7812/');
+    const isIgnoredDevtoolsSocketError =
+      text.includes('vite_devtools_auth_token') || text.includes('ws://localhost:7812/');
     if (message.type() === 'error' && !isIgnoredDevtoolsSocketError) {
       errors.push(`console.error: ${text}`);
     }
@@ -105,15 +110,44 @@ function assertNoVisibleErrorMessages(text: string, label: string): void {
   assert(!match, `${label} must not show an error message matching ${String(match)}`);
 }
 
-async function openRegisterPage(page: Page, frontendUrl: string, ars?: string, name?: string): Promise<string> {
+async function openRegisterPage(
+  page: Page,
+  frontendUrl: string,
+  ars?: string,
+  name?: string,
+  slug?: string,
+): Promise<string> {
   const url = new URL('/register_localteam', frontendUrl);
   if (ars) url.searchParams.set('ars', ars);
   if (name) url.searchParams.set('name', name);
+  if (slug) url.searchParams.set('slug', slug);
 
   await page.goto(url.toString(), { waitUntil: 'domcontentloaded' });
   await page.waitForLoadState('networkidle').catch(() => undefined);
   await page.waitForTimeout(750);
   return visibleText(page);
+}
+
+async function readCurrentBackendScore(
+  admin: DirectusClient,
+  municipalityId: string,
+): Promise<MunicipalityScore | undefined> {
+  const scores = await admin.readItems<MunicipalityScore>('municipality_scores', {
+    filter: {
+      municipality: { _eq: municipalityId },
+      catalog_version: { isCurrentBackend: { _eq: true } },
+    },
+    fields: [
+      'id',
+      'municipality',
+      'percentage_rated',
+      'published',
+      'catalog_version.id',
+      'catalog_version.isCurrentBackend',
+    ],
+    limit: 1,
+  });
+  return scores[0];
 }
 
 async function mockStadtlandzahlArea(page: Page, ars: string, name: string): Promise<void> {
@@ -141,10 +175,9 @@ async function mockStadtlandzahlArea(page: Page, ars: string, name: string): Pro
 
 async function solveAltcha(page: Page): Promise<void> {
   await page.locator('altcha-widget').waitFor({ state: 'attached', timeout: 20_000 });
-  await page.waitForFunction(
-    () => typeof (document.querySelector('altcha-widget') as any)?.verify === 'function',
-    { timeout: 20_000 },
-  );
+  await page.waitForFunction(() => typeof (document.querySelector('altcha-widget') as any)?.verify === 'function', {
+    timeout: 20_000,
+  });
 
   const result = await page.evaluate(async () => {
     const widget = document.querySelector('altcha-widget') as any;
@@ -156,26 +189,15 @@ async function solveAltcha(page: Page): Promise<void> {
   });
 
   assert(result.hasPayload, `Altcha verification must return a payload. State: ${result.state ?? 'unknown'}`);
-  await page.waitForFunction(
-    () => (document.querySelector('altcha-widget') as any)?.getState?.() === 'verified',
-    { timeout: 60_000 },
-  );
+  await page.waitForFunction(() => (document.querySelector('altcha-widget') as any)?.getState?.() === 'verified', {
+    timeout: 60_000,
+  });
 }
 
 async function readUserByEmail(admin: DirectusClient, email: string): Promise<DirectusUser | undefined> {
   const users = await admin.readUsers<DirectusUser>({
     filter: { email: { _eq: email } },
-    fields: [
-      'id',
-      'email',
-      'first_name',
-      'last_name',
-      'title',
-      'description',
-      'status',
-      'verified',
-      'role.name',
-    ],
+    fields: ['id', 'email', 'first_name', 'last_name', 'title', 'description', 'status', 'verified', 'role.name'],
     limit: 1,
   });
   return users[0];
@@ -190,18 +212,13 @@ async function readLocalteamByName(admin: DirectusClient, name: string): Promise
   return localteams[0];
 }
 
-async function readMunicipalityByLocalteam(admin: DirectusClient, localteamId: string): Promise<Municipality | undefined> {
+async function readMunicipalityByLocalteam(
+  admin: DirectusClient,
+  localteamId: string,
+): Promise<Municipality | undefined> {
   const municipalities = await admin.readItems<Municipality>('municipalities', {
     filter: { localteam_id: { _eq: localteamId } },
-    fields: [
-      'id',
-      'name',
-      'slug',
-      'ars',
-      'creator_verified',
-      'preview_token',
-      'localteam_id',
-    ],
+    fields: ['id', 'name', 'slug', 'ars', 'creator_verified', 'preview_token', 'localteam_id'],
     limit: 1,
   });
   return municipalities[0];
@@ -226,11 +243,12 @@ async function createExistingLocalteamFixture(
   fixture: TestFixture,
   municipalityName: string,
   ars: string,
+  scenario = 'default',
 ): Promise<{ localteam: Localteam; municipality: Municipality }> {
   const localteam = await fixture.admin.createItem<Localteam>('localteams', {
-    name: `Automated Existing Lokalteam ${fixture.config.runId}`,
+    name: `Automated Existing Lokalteam ${scenario} ${fixture.config.runId}`,
     municipality_name: municipalityName,
-    slug: `automated-existing-localteam-${fixture.config.runId}`,
+    slug: `automated-existing-localteam-${scenario}-${fixture.config.runId}`,
     status: 'published',
   });
 
@@ -270,12 +288,42 @@ export async function runRegisterLocalteamFlow(
 ): Promise<void> {
   const newArs = validTestArs(fixture.config.runId, 17);
   const existingArs = validTestArs(fixture.config.runId, 31);
+  const inProgressArs = validTestArs(fixture.config.runId, 47);
+  const publishedArs = validTestArs(fixture.config.runId, 59);
+  const staleSlugArs = validTestArs(fixture.config.runId, 71);
   const newMunicipalityName = `Automated Register New ${fixture.config.runId}`;
   const existingMunicipalityName = `Automated Register Existing ${fixture.config.runId}`;
+  const inProgressMunicipalityName = `Automated Register In Progress ${fixture.config.runId}`;
+  const publishedMunicipalityName = `Automated Register Published ${fixture.config.runId}`;
+  const staleSlugMunicipalityName = `Automated Register No Team ${fixture.config.runId}`;
   const newUserEmail = `automated-register-new-${fixture.config.runId}@stadt-land-klima.de`;
   const newLocalteamName = `Stadt.Land.Klima! ${newMunicipalityName}`;
   let newUserId: string | null = null;
   let newLocalteamId: string | null = null;
+
+  await runner.step('Register localteam: municipality search excludes higher-level regions', async () => {
+    const context = await newContext(browser);
+    const page = await context.newPage();
+    try {
+      await page.route(
+        (url) => url.pathname === '/api/area-search',
+        async (route) =>
+          route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: '[]',
+          }),
+      );
+      await openRegisterPage(page, fixture.config.frontendUrl);
+      const requestPromise = page.waitForRequest((request) => request.url().includes('/api/area-search?'));
+      await page.locator('#municipality-search').pressSequentially('Bayern');
+      const request = await requestPromise;
+      const mode = new URL(request.url()).searchParams.get('mode');
+      assertEqual(mode, 'reasonable', 'Register search must request only reasonable municipalities');
+    } finally {
+      await context.close();
+    }
+  });
 
   await runner.step('Register localteam: frontend page creates a new localteam request', async () => {
     const context = await newContext(browser);
@@ -289,9 +337,17 @@ export async function runRegisterLocalteamFlow(
       assertIncludes(initialText, 'Gemeinde / Stadt suchen', 'Register page must expose municipality search');
 
       const text = await openRegisterPage(page, fixture.config.frontendUrl, newArs, newMunicipalityName);
-      assertIncludes(text, newMunicipalityName, 'Register page must show the selected municipality from the frontend URL');
+      assertIncludes(
+        text,
+        newMunicipalityName,
+        'Register page must show the selected municipality from the frontend URL',
+      );
       assertIncludes(text, 'Deine Kontaktdaten', 'New municipality must show the registration form');
-      assertNotIncludes(text, 'Lokalteam aktiv - Bewertung läuft', 'New municipality must not show the join-existing-team state');
+      assertNotIncludes(
+        text,
+        'Lokalteam aktiv - Bewertung läuft',
+        'New municipality must not show the join-existing-team state',
+      );
       assertNoVisibleErrorMessages(text, 'Register new localteam page');
 
       await page.locator('#reg-firstname').fill('Automated');
@@ -301,8 +357,7 @@ export async function runRegisterLocalteamFlow(
       await solveAltcha(page);
 
       const responsePromise = page.waitForResponse(
-        (response) => response.url().includes('/api/register-municipality')
-          && response.request().method() === 'POST',
+        (response) => response.url().includes('/api/register-municipality') && response.request().method() === 'POST',
         { timeout: 60_000 },
       );
       await page.getByRole('button', { name: /Lokalteam beantragen/i }).click();
@@ -334,7 +389,11 @@ export async function runRegisterLocalteamFlow(
     assertEqual(roleName(user), 'LokalteamAdmin', 'Register localteam user must be a LokalteamAdmin');
     assertEqual(user.first_name, 'Automated', 'Register localteam user must keep the first name');
     assertEqual(user.last_name, 'Register', 'Register localteam user must keep the last name');
-    assertEqual(user.title, `Automated Organisation ${fixture.config.runId}`, 'Register localteam user must keep the organisation');
+    assertEqual(
+      user.title,
+      `Automated Organisation ${fixture.config.runId}`,
+      'Register localteam user must keep the organisation',
+    );
     assertIncludes(user.description ?? '', newArs, 'Register localteam user description must contain the ARS');
 
     const localteam = await waitFor(
@@ -348,7 +407,11 @@ export async function runRegisterLocalteamFlow(
     assertEqual(relationId(localteam.admin_id), user.id, 'Created localteam must assign the registering user as admin');
 
     const junctions = await readLocalteamUserJunctions(fixture.admin, user.id, localteam.id);
-    assertEqual(junctions.length, 1, 'Register localteam must link the new admin user to the new localteam exactly once');
+    assertEqual(
+      junctions.length,
+      1,
+      'Register localteam must link the new admin user to the new localteam exactly once',
+    );
 
     const municipality = await waitFor(
       'municipality patched by register_localteam frontend submit',
@@ -360,7 +423,11 @@ export async function runRegisterLocalteamFlow(
     );
     assertEqual(municipality.name, newMunicipalityName, 'Created municipality must keep the selected name');
     assertEqual(municipality.creator_verified, false, 'Created municipality must start unverified');
-    assertEqual(relationId(municipality.localteam_id), localteam.id, 'Created municipality must link to the new localteam');
+    assertEqual(
+      relationId(municipality.localteam_id),
+      localteam.id,
+      'Created municipality must link to the new localteam',
+    );
     assert(municipality.preview_token, 'Created municipality must get a preview token');
   });
 
@@ -369,31 +436,156 @@ export async function runRegisterLocalteamFlow(
       fixture,
       existingMunicipalityName,
       existingArs,
+      'not-started',
     );
     assert(municipality.slug, 'Existing localteam fixture municipality must have a slug');
 
-    const context = await newContext(browser, { viewport: { width: 390, height: 900 } });
+    const context = await newContext(browser, {
+      viewport: { width: 390, height: 900 },
+    });
     const page = await context.newPage();
     const browserErrors = watchPageErrors(page, 'Join existing localteam page');
 
     try {
       await mockStadtlandzahlArea(page, existingArs, existingMunicipalityName);
       const text = await openRegisterPage(page, fixture.config.frontendUrl, existingArs, existingMunicipalityName);
-      await page.getByText('Lokalteam aktiv - Bewertung läuft').waitFor({ state: 'visible', timeout: 30_000 });
+      await page
+        .getByText('Lokalteam aktiv – Bewertung noch nicht begonnen')
+        .waitFor({ state: 'visible', timeout: 30_000 });
       const visible = await visibleText(page);
       assertIncludes(visible, existingMunicipalityName, 'Existing localteam page must show the selected municipality');
-      assertIncludes(visible, 'Lokalteam aktiv - Bewertung läuft', 'Existing localteam page must show the in-progress localteam state');
+      assertIncludes(
+        visible,
+        'Lokalteam aktiv – Bewertung noch nicht begonnen',
+        'A zero-percent rating must show the not-started state',
+      );
+      assertNotIncludes(
+        visible,
+        'Lokalteam aktiv - Bewertung läuft',
+        'A zero-percent rating must not show the in-progress state',
+      );
       assertIncludes(visible, 'Kontakt aufnehmen', 'Existing localteam page must offer a contact action');
-      assertNotIncludes(visible, 'Deine Kontaktdaten', 'Existing localteam page must not show the new-team registration form');
+      assertNotIncludes(
+        visible,
+        'Deine Kontaktdaten',
+        'Existing localteam page must not show the new-team registration form',
+      );
       assertNotIncludes(visible, 'Lokalteam beantragen', 'Existing localteam page must not show the submit button');
       assertNoVisibleErrorMessages(text, 'Join existing localteam initial page');
       assertNoVisibleErrorMessages(visible, 'Join existing localteam visible page');
 
-      const contactHref = await page.getByRole('link', { name: /Kontakt aufnehmen/i }).first().getAttribute('href');
+      const contactHref = await page
+        .getByRole('link', { name: /Kontakt aufnehmen/i })
+        .first()
+        .getAttribute('href');
       assert(contactHref, 'Existing localteam contact action must be a link');
-      assert(contactHref.startsWith('/contact?'), 'Existing localteam contact action must point to the frontend contact page');
-      assertIncludes(decodeURIComponent(contactHref), existingMunicipalityName, 'Existing localteam contact link must include municipality context');
+      assert(
+        contactHref.startsWith('/contact?'),
+        'Existing localteam contact action must point to the frontend contact page',
+      );
+      assertIncludes(
+        decodeURIComponent(contactHref),
+        existingMunicipalityName,
+        'Existing localteam contact link must include municipality context',
+      );
       browserErrors.assertNoErrors();
+    } finally {
+      await context.close();
+    }
+  });
+
+  await runner.step('Register localteam: started current rating is shown as in progress', async () => {
+    const { municipality } = await createExistingLocalteamFixture(
+      fixture,
+      inProgressMunicipalityName,
+      inProgressArs,
+      'in-progress',
+    );
+    const score = await waitFor(
+      'current backend score for in-progress register_localteam scenario',
+      async () => readCurrentBackendScore(fixture.admin, municipality.id) ?? false,
+      { timeoutMs: 30_000 },
+    );
+    await fixture.admin.updateItem<MunicipalityScore>('municipality_scores', score.id, {
+      percentage_rated: 25,
+    });
+
+    const context = await newContext(browser);
+    const page = await context.newPage();
+    try {
+      await mockStadtlandzahlArea(page, inProgressArs, inProgressMunicipalityName);
+      const text = await openRegisterPage(page, fixture.config.frontendUrl, inProgressArs, inProgressMunicipalityName);
+      assertIncludes(
+        text,
+        'Lokalteam aktiv - Bewertung läuft',
+        'A started unpublished current rating must be in progress',
+      );
+      assertNotIncludes(text, 'Bewertung abgeschlossen', 'An unpublished current rating must not be complete');
+      assertNotIncludes(text, 'Bewertung noch nicht begonnen', 'A started rating must not show the not-started state');
+    } finally {
+      await context.close();
+    }
+  });
+
+  await runner.step('Register localteam: published current rating is complete regardless of percentage', async () => {
+    const { localteam, municipality } = await createExistingLocalteamFixture(
+      fixture,
+      publishedMunicipalityName,
+      publishedArs,
+      'published',
+    );
+    const score = await waitFor(
+      'current backend score for published register_localteam scenario',
+      async () => readCurrentBackendScore(fixture.admin, municipality.id) ?? false,
+      { timeoutMs: 30_000 },
+    );
+    await fixture.admin.updateItem<MunicipalityScore>('municipality_scores', score.id, {
+      percentage_rated: 0,
+    });
+    await fixture.admin.createItem('junction_directus_users_localteams', {
+      directus_users_id: fixture.localteamMember.id,
+      localteam_id: localteam.id,
+    });
+    await fixture.localteamMember.client.updateItem<MunicipalityScore>('municipality_scores', score.id, {
+      published: true,
+    });
+
+    const context = await newContext(browser);
+    const page = await context.newPage();
+    try {
+      await mockStadtlandzahlArea(page, publishedArs, publishedMunicipalityName);
+      const text = await openRegisterPage(page, fixture.config.frontendUrl, publishedArs, publishedMunicipalityName);
+      assertIncludes(
+        text,
+        'Bewertung abgeschlossen',
+        'A published current rating must be complete regardless of percentage',
+      );
+      assertNotIncludes(
+        text,
+        'Lokalteam aktiv - Bewertung läuft',
+        'A published current rating must not be in progress',
+      );
+      assertNotIncludes(text, 'Bewertung noch nicht begonnen', 'A published current rating must not be not-started');
+    } finally {
+      await context.close();
+    }
+  });
+
+  await runner.step('Register localteam: stale slug cannot impersonate an existing team', async () => {
+    const context = await newContext(browser);
+    const page = await context.newPage();
+    try {
+      await mockStadtlandzahlArea(page, staleSlugArs, staleSlugMunicipalityName);
+      const text = await openRegisterPage(
+        page,
+        fixture.config.frontendUrl,
+        staleSlugArs,
+        staleSlugMunicipalityName,
+        'berlin',
+      );
+      assertIncludes(text, 'Deine Kontaktdaten', 'A stale URL slug without a matching team must show registration');
+      assertNotIncludes(text, 'Lokalteam aktiv', 'A stale URL slug must not create an existing-team state');
+      assertNotIncludes(text, 'Bewertung abgeschlossen', 'A stale URL slug must not create a completed state');
     } finally {
       await context.close();
     }

--- a/src/directus/translations/de-DE/localteam.active_rating_not_started.de-DE.yaml
+++ b/src/directus/translations/de-DE/localteam.active_rating_not_started.de-DE.yaml
@@ -1,0 +1,3 @@
+language: de-DE
+key: localteam.active_rating_not_started
+value: Lokalteam aktiv – Bewertung noch nicht begonnen

--- a/src/directus/translations/de-DE/localteam.register.not_started.body.de-DE.yaml
+++ b/src/directus/translations/de-DE/localteam.register.not_started.body.de-DE.yaml
@@ -1,0 +1,6 @@
+language: de-DE
+key: localteam.register.not_started.body
+value:
+  In <strong>:name</strong> gibt es bereits ein Lokalteam. Die Bewertung des
+  aktuellen Maßnahmenkatalogs wurde noch nicht begonnen. Möchtest du das Team
+  unterstützen?

--- a/src/directus/translations/de-DE/rating.not_started.de-DE.yaml
+++ b/src/directus/translations/de-DE/rating.not_started.de-DE.yaml
@@ -1,0 +1,3 @@
+language: de-DE
+key: rating.not_started
+value: Bewertung noch nicht begonnen

--- a/src/directus/translations/en-GB/localteam.active_rating_not_started.en-GB.yaml
+++ b/src/directus/translations/en-GB/localteam.active_rating_not_started.en-GB.yaml
@@ -1,0 +1,3 @@
+language: en-GB
+key: localteam.active_rating_not_started
+value: Local team active – rating not started yet

--- a/src/directus/translations/en-GB/localteam.register.not_started.body.en-GB.yaml
+++ b/src/directus/translations/en-GB/localteam.register.not_started.body.en-GB.yaml
@@ -1,0 +1,5 @@
+language: en-GB
+key: localteam.register.not_started.body
+value:
+  There is already a local team in <strong>:name</strong>. It has not started
+  rating the current catalogue of measures yet. Would you like to support the team?

--- a/src/directus/translations/en-GB/rating.not_started.en-GB.yaml
+++ b/src/directus/translations/en-GB/rating.not_started.en-GB.yaml
@@ -1,0 +1,3 @@
+language: en-GB
+key: rating.not_started
+value: Rating not started yet

--- a/src/directus/translations/it-IT/localteam.active_rating_not_started.it-IT.yaml
+++ b/src/directus/translations/it-IT/localteam.active_rating_not_started.it-IT.yaml
@@ -1,0 +1,3 @@
+language: it-IT
+key: localteam.active_rating_not_started
+value: Gruppo locale attivo – valutazione non ancora iniziata

--- a/src/directus/translations/it-IT/localteam.register.not_started.body.it-IT.yaml
+++ b/src/directus/translations/it-IT/localteam.register.not_started.body.it-IT.yaml
@@ -1,0 +1,4 @@
+language: it-IT
+key: localteam.register.not_started.body
+value: A <strong>:name</strong> esiste già un gruppo locale. La valutazione del
+  catalogo delle misure attuale non è ancora iniziata. Vuoi sostenere il gruppo?

--- a/src/directus/translations/it-IT/rating.not_started.it-IT.yaml
+++ b/src/directus/translations/it-IT/rating.not_started.it-IT.yaml
@@ -1,0 +1,3 @@
+language: it-IT
+key: rating.not_started
+value: Valutazione non ancora iniziata

--- a/src/frontend/components/AreaSearchResult.vue
+++ b/src/frontend/components/AreaSearchResult.vue
@@ -32,6 +32,20 @@
         </button>
       </template>
 
+      <!-- Localteam exists, but the current catalog has not been started -->
+      <template v-else-if="result.ctaType === 'not-started'">
+        <span class="bg-gray-100 text-gray-700 whitespace-nowrap rounded-full px-2 py-0.5 text-xs">
+          {{ $t("rating.not_started") }}
+        </span>
+        <button
+          type="button"
+          class="whitespace-nowrap rounded-full border border-solid-olive-green-30 bg-solid-olive-green-10 px-2 py-0.5 text-xs text-olive-green transition-colors hover:bg-solid-olive-green-20"
+          @click.stop="$emit('chip-action', { action: 'mitmachen', ars: result.ars, result })"
+        >
+          {{ $t("generic.join_now") }}
+        </button>
+      </template>
+
       <!-- None: register CTA -->
       <button
         v-else-if="result.ctaType === 'none'"

--- a/src/frontend/composables/getCatalogVersion.js
+++ b/src/frontend/composables/getCatalogVersion.js
@@ -35,6 +35,22 @@ export async function getCurrentFrontendCatalogVersion($directus, $readItems) {
   return response?.[0];
 }
 
+export async function getCurrentBackendCatalogVersion($directus, $readItems) {
+  const response = await $directus.request(
+    $readItems("measure_catalog", {
+      fields: ["id", "name", "isCurrentFrontend", "isCurrentBackend"],
+      filter: { hidden: { _eq: false }, isCurrentBackend: { _eq: true } },
+      limit: -1,
+    })
+  );
+
+  if (response?.length !== 1) {
+    throw new Error("Exactly one visible catalog version with isCurrentBackend===true is required.");
+  }
+
+  return response[0];
+}
+
 // Fetches the catalog version and updates the URL to match it
 export async function setCatalogVersionUrl(route, router, selectedCatalogVersion) {
   // Change the URL to match the catalog version, if it didn't to begin with

--- a/src/frontend/composables/useAreaSearch.js
+++ b/src/frontend/composables/useAreaSearch.js
@@ -7,25 +7,34 @@
  *
  * @param {object} options
  * @param {string | import('vue').Ref<string>} options.mode
- *   'normal'     – level 1-3 regions + reasonable municipalities (used by command palette, register)
+ *   'normal'     – level 1-3 regions + reasonable municipalities (used by command palette)
  *   'reasonable' – isReasonableForMunicipalRating only (hero block)
  *   'all'        – no filter (stats page)
  * @param {import('vue').Ref<Set<string>> | Set<string> | null} options.publishedSlugs
  *   Reactive set of published municipality slugs. Used to determine ctaType.
  * @param {import('vue').Ref<string|null> | string | null} options.catalogVersionName
  *   Optional catalog version name to prefer when resolving stadtlandklimaDataAll.
+ * @param {import('vue').Ref<string|null> | string | null} options.statusCatalogVersionId
+ *   Optional Directus catalog ID. When set, team and publication status are
+ *   resolved from Directus for exactly this catalog instead of inferred from slugs.
  */
 import { ref, computed, isRef } from 'vue'
 import lodash from 'lodash'
 const { debounce } = lodash
 import { getScorePercentageColor, getStateFromArs } from '~/shared/utils.js'
 
-export function useAreaSearch({ mode = 'reasonable', publishedSlugs = null, catalogVersionName = null } = {}) {
+export function useAreaSearch({
+  mode = 'reasonable',
+  publishedSlugs = null,
+  catalogVersionName = null,
+  statusCatalogVersionId = null,
+} = {}) {
   const { $stadtlandzahlAPI, $directus, $readItems } = useNuxtApp()
 
   // Allow mode and catalogVersionName to be passed as plain strings or reactive refs
   const modeRef = isRef(mode) ? mode : ref(mode)
   const catalogRef = isRef(catalogVersionName) ? catalogVersionName : ref(catalogVersionName)
+  const statusCatalogRef = isRef(statusCatalogVersionId) ? statusCatalogVersionId : ref(statusCatalogVersionId)
 
   const rawResults = ref([])
   const isLoading = ref(false)
@@ -62,16 +71,30 @@ export function useAreaSearch({ mode = 'reasonable', publishedSlugs = null, cata
 
       _slug = ratingData?.slug ?? null
 
-      const isPublished = !!(ratingData?.slug && slugs.has(ratingData.slug))
+      const exactStatus = area.directusCatalogStatus
+      const isPublished = exactStatus
+        ? exactStatus.published === true
+        : !!(ratingData?.slug && slugs.has(ratingData.slug))
 
-      if (isPublished) {
-        ctaType              = 'complete'
-        scoreDisplay         = ratingData.scoreTotal != null
-          ? `${Math.round(Number(ratingData.scoreTotal))}%`
-          : null
-        scoreTotalColorClass = ratingData.scoreTotal != null
-          ? getScorePercentageColor(parseFloat(ratingData.scoreTotal))
-          : null
+      if (exactStatus) {
+        _slug = exactStatus.slug ?? _slug
+        if (!exactStatus.hasLocalteam) {
+          ctaType = 'none'
+        } else if (isPublished) {
+          ctaType = 'complete'
+          scoreDisplay = exactStatus.scoreTotal != null ? `${Math.round(Number(exactStatus.scoreTotal))}%` : null
+          scoreTotalColorClass =
+            exactStatus.scoreTotal != null ? getScorePercentageColor(parseFloat(exactStatus.scoreTotal)) : null
+        } else if (Number(exactStatus.percentageRated ?? 0) > 0) {
+          ctaType = 'in-progress'
+        } else {
+          ctaType = 'not-started'
+        }
+      } else if (isPublished) {
+        ctaType = 'complete'
+        scoreDisplay = ratingData.scoreTotal != null ? `${Math.round(Number(ratingData.scoreTotal))}%` : null
+        scoreTotalColorClass =
+          ratingData.scoreTotal != null ? getScorePercentageColor(parseFloat(ratingData.scoreTotal)) : null
       } else if (ratingData?.slug || area.hasLocalteam) {
         ctaType = 'in-progress'
       } else if (area.isReasonableForMunicipalRating) {
@@ -103,6 +126,60 @@ export function useAreaSearch({ mode = 'reasonable', publishedSlugs = null, cata
     isLoading.value = true
     try {
       const nodes = await $stadtlandzahlAPI.searchAdministrativeAreas(term.trim(), modeRef.value)
+
+      const requestedCatalogId = statusCatalogRef.value
+      if (requestedCatalogId) {
+        const arsCodes = nodes.map((n) => n.ars).filter(Boolean)
+        const candidateSlugs = [
+          ...new Set(nodes.flatMap((n) => (n.stadtlandklimaDataAll ?? []).map((item) => item.slug).filter(Boolean))),
+        ]
+        const identityFilters = []
+        if (arsCodes.length > 0) identityFilters.push({ ars: { _in: arsCodes } })
+        if (candidateSlugs.length > 0) identityFilters.push({ slug: { _in: candidateSlugs } })
+
+        let municipalities = []
+        if (identityFilters.length > 0) {
+          try {
+            municipalities = await $directus.request(
+              $readItems('municipalities', {
+                filter: { _or: identityFilters },
+                fields: [
+                  'ars',
+                  'slug',
+                  'localteam_id',
+                  { scores: ['catalog_version', 'published', 'percentage_rated', 'score_total'] },
+                ],
+                limit: -1,
+              }),
+            )
+          } catch {
+            municipalities = []
+          }
+        }
+
+        rawResults.value = nodes.map((node) => {
+          const nodeSlugs = new Set((node.stadtlandklimaDataAll ?? []).map((item) => item.slug).filter(Boolean))
+          const municipality =
+            municipalities.find((item) => item.slug && nodeSlugs.has(item.slug)) ??
+            municipalities.find((item) => item.ars && item.ars === node.ars)
+          const score = municipality?.scores?.find((item) => {
+            const catalogId = typeof item.catalog_version === 'object' ? item.catalog_version?.id : item.catalog_version
+            return catalogId === requestedCatalogId
+          })
+
+          return {
+            ...node,
+            directusCatalogStatus: {
+              hasLocalteam: !!municipality?.localteam_id,
+              slug: municipality?.slug ?? null,
+              published: score?.published === true,
+              percentageRated: score?.percentage_rated ?? null,
+              scoreTotal: score?.score_total ?? null,
+            },
+          }
+        })
+        return
+      }
 
       // Enrich municipality nodes with localteam_id from Directus so that
       // municipalities with a registered localteam but no rating slug yet

--- a/src/frontend/pages/register_localteam.vue
+++ b/src/frontend/pages/register_localteam.vue
@@ -175,8 +175,8 @@
         </div>
 
         <!-- Already has a local team → contact prompt -->
-        <!-- Case 1: Localteam exists AND rating is complete (≥98%) -->
-        <div v-if="hasExistingTeam && existingPercentageRated != null && existingPercentageRated >= 98" class="rounded-sm shadow-list p-4 sm:p-8 bg-white">
+        <!-- Case 1: Current backend catalog rating is published -->
+        <div v-if="ratingState === 'complete'" class="rounded-sm shadow-list p-4 sm:p-8 bg-white">
           <div class="flex items-start gap-3 sm:gap-4 mb-5">
             <div class="flex-shrink-0 w-10 h-10 rounded-full bg-green-100 flex items-center justify-center">
               <svg class="w-5 h-5 text-green" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -217,8 +217,8 @@
           </button>
         </div>
 
-        <!-- Case 2: Localteam exists but rating is still in progress -->
-        <div v-else-if="hasExistingTeam" class="rounded-sm shadow-list p-4 sm:p-8 bg-white">
+        <!-- Case 2: Localteam exists and the current rating has been started -->
+        <div v-else-if="ratingState === 'in-progress'" class="rounded-sm shadow-list p-4 sm:p-8 bg-white">
           <div class="flex items-start gap-3 sm:gap-4 mb-5">
             <div class="flex-shrink-0 w-10 h-10 rounded-full bg-yellow-100 flex items-center justify-center">
               <svg class="w-5 h-5 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -229,6 +229,40 @@
               <h2 class="font-heading text-h2 font-bold text-gray-800 mb-1">{{ $t("localteam.active_rating_in_progress") }}</h2>
               <p class="text-sm text-gray-600">
                 <span v-html="$t('localteam.register.in_progress.body', { ':name': selectedArea.name })"></span>
+              </p>
+            </div>
+          </div>
+          <div class="flex flex-col sm:flex-row gap-3">
+            <CanonicalButton
+              :href="`/contact?title=${encodeURIComponent($t('localteam.contact_title', { ':name': selectedArea.name }))}&type=cooperation&content=${encodeURIComponent($t('localteam.contact_content', { ':name': selectedArea.name }))}`"
+              :label="$t('generic.contact')"
+              icon-slug="icon_login_arrow"
+              color="blue"
+              class="flex-1"
+            />
+          </div>
+          <button
+            v-if="!hasQueryParams"
+            type="button"
+            class="mt-4 text-sm text-light-blue hover:underline block"
+            @click="resetSelection"
+          >
+            {{ $t("localteam.register.select_other_municipality") }}
+          </button>
+        </div>
+
+        <!-- Case 3: Localteam exists, but the current rating has not been started -->
+        <div v-else-if="ratingState === 'not-started'" class="rounded-sm shadow-list p-4 sm:p-8 bg-white">
+          <div class="flex items-start gap-3 sm:gap-4 mb-5">
+            <div class="flex-shrink-0 w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center">
+              <svg class="w-5 h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </div>
+            <div>
+              <h2 class="font-heading text-h2 font-bold text-gray-800 mb-1">{{ $t("localteam.active_rating_not_started") }}</h2>
+              <p class="text-sm text-gray-600">
+                <span v-html="$t('localteam.register.not_started.body', { ':name': selectedArea.name })"></span>
               </p>
             </div>
           </div>
@@ -271,11 +305,12 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
 import { useAreaSearch } from '~/composables/useAreaSearch.js'
+import { getCurrentBackendCatalogVersion } from '~/composables/getCatalogVersion.js'
 
 const route = useRoute()
 const router = useRouter()
-const { $stadtlandzahlAPI, $t } = useNuxtApp()
-const { public: { clientDirectusUrl, directusToken } } = useRuntimeConfig()
+const { $stadtlandzahlAPI, $directus, $readItems, $t } = useNuxtApp()
+const currentVersionBackend = await getCurrentBackendCatalogVersion($directus, $readItems)
 
 // --- Query-param pre-fill ---
 const hasQueryParams = computed(() => !!route.query.ars)
@@ -293,16 +328,30 @@ const registrationSuccess = ref(false)
 const selectedArea = ref<AreaInfo | null>(null)
 const existingSlug = ref<string | null>(null)
 const existingPercentageRated = ref<number | null>(null)
+const existingScorePublished = ref(false)
 const hasExistingTeam = ref(false)
 const areaGeoData = ref<{ geo_center: any; geo_area: any } | null>(null)
 const geoLoading = ref(false)
 
-// --- Search ---
-const { data: publishedMunicipalities } = useNuxtData('municipalities')
-const publishedSlugs = computed(() => new Set((publishedMunicipalities.value ?? []).map((m: any) => m.slug)))
+const ratingState = computed<'none' | 'not-started' | 'in-progress' | 'complete'>(() => {
+  if (!hasExistingTeam.value) return 'none'
+  if (existingScorePublished.value) return 'complete'
+  if (Number(existingPercentageRated.value ?? 0) > 0) return 'in-progress'
+  return 'not-started'
+})
 
+// --- Search ---
 const searchQuery = ref('')
-const { results: searchResults, isLoading, search, clear } = useAreaSearch({ mode: 'normal', publishedSlugs: publishedSlugs as any })
+const {
+  results: searchResults,
+  isLoading,
+  search,
+  clear,
+} = useAreaSearch({
+  mode: 'reasonable',
+  catalogVersionName: currentVersionBackend.name,
+  statusCatalogVersionId: currentVersionBackend.id,
+})
 const searchInputRef = ref<HTMLElement | null>(null)
 const focusedIndex = ref(-1)
 
@@ -340,12 +389,8 @@ async function selectArea(area: any) {
   // Collect slugs from the stadtlandzahl search result — these are Directus municipality slugs
   // associated to this ARS. We must still check whether each one has a localteam_id.
   const existingSlugs: string[] = (area.stadtlandklimaDataAll ?? []).map((d: any) => d.slug).filter(Boolean)
-  // Use known percentageRated from search result to avoid an extra API call
-  const knownPercentageRated: number | null = area.stadtlandklimaDataAll?.[0]?.percentageRated ?? null
-  const teamInfo = await checkExistingLocalteam(area.ars, existingSlugs, knownPercentageRated)
-  existingSlug.value = teamInfo.slug
-  existingPercentageRated.value = teamInfo.percentageRated
-  hasExistingTeam.value = !!teamInfo.slug
+  const teamInfo = await checkExistingLocalteam(area.ars, existingSlugs)
+  applyTeamInfo(teamInfo)
   await fetchGeoData(area.ars)
 }
 
@@ -353,6 +398,7 @@ function resetSelection() {
   selectedArea.value = null
   existingSlug.value = null
   existingPercentageRated.value = null
+  existingScorePublished.value = false
   hasExistingTeam.value = false
   areaGeoData.value = null
   focusedIndex.value = -1
@@ -362,77 +408,60 @@ function resetSelection() {
 async function checkExistingLocalteam(
   ars: string,
   slugs: string[] = [],
-  knownPercentageRated?: number | null,
-): Promise<{ slug: string | null; percentageRated: number | null }> {
+): Promise<{ hasTeam: boolean; slug: string | null; percentageRated: number | null; published: boolean }> {
   try {
-    const authHeaders = directusToken ? { Authorization: `Bearer ${directusToken}` } : undefined
-    let foundSlug: string | null = null
+    const identityFilters: any[] = [{ ars: { _eq: ars } }]
+    const uniqueSlugs = [...new Set(slugs.filter(Boolean))]
+    if (uniqueSlugs.length > 0) identityFilters.push({ slug: { _in: uniqueSlugs } })
 
-    // Prefer slug-based lookup: the createMunicipality flow creates records without ARS,
-    // but always sets localteam_id. Checking by slug + localteam_id is reliable.
-    if (slugs.length) {
-      const result = await $fetch<{ data: Array<{ slug: string | null; localteam_id: string | null }> }>(
-        `${clientDirectusUrl}/items/municipalities`,
-        {
-          params: {
-            'filter[slug][_in]': slugs.join(','),
-            'filter[localteam_id][_nnull]': true,
-            'fields[]': ['slug', 'localteam_id'],
-            limit: slugs.length,
-          },
-          headers: authHeaders,
-        }
-      )
-      foundSlug = result.data?.find(m => m.localteam_id)?.slug ?? null
+    const municipalities = await $directus.request(
+      $readItems('municipalities', {
+        filter: {
+          _and: [{ localteam_id: { _nnull: true } }, { _or: identityFilters }],
+        },
+        fields: ['ars', 'slug', 'localteam_id', { scores: ['catalog_version', 'published', 'percentage_rated'] }],
+        limit: -1,
+      }),
+    )
+
+    const municipality =
+      uniqueSlugs.map((slug) => municipalities.find((item: any) => item.slug === slug)).find(Boolean) ??
+      municipalities.find((item: any) => item.ars === ars)
+
+    if (!municipality?.localteam_id) {
+      return { hasTeam: false, slug: null, percentageRated: null, published: false }
     }
 
-    if (!foundSlug) {
-      // Fallback: ARS-based lookup (works for municipalities updated by step 3 of registration)
-      const result = await $fetch<{ data: Array<{ slug: string | null }> }>(
-        `${clientDirectusUrl}/items/municipalities`,
-        {
-          params: {
-            'filter[ars][_eq]': ars,
-            'filter[localteam_id][_nnull]': true,
-            'fields[]': 'slug',
-            limit: 1,
-          },
-          headers: authHeaders,
-        }
-      )
-      foundSlug = result.data?.[0]?.slug ?? null
-    }
+    const score = (municipality.scores ?? []).find((item: any) => {
+      const catalogId = typeof item.catalog_version === 'object' ? item.catalog_version?.id : item.catalog_version
+      return catalogId === currentVersionBackend.id
+    })
 
-    if (!foundSlug) return { slug: null, percentageRated: null }
-
-    // Resolve percentage_rated: use search-provided value if available, otherwise query scores
-    if (knownPercentageRated != null) {
-      return { slug: foundSlug, percentageRated: knownPercentageRated }
-    }
-    try {
-      const scores = await $fetch<{ data: Array<{ percentage_rated: number | null }> }>(
-        `${clientDirectusUrl}/items/municipality_scores`,
-        {
-          params: {
-            'filter[municipality][slug][_eq]': foundSlug,
-            'fields[]': 'percentage_rated',
-            limit: 1,
-            sort: '-percentage_rated',
-          },
-          headers: authHeaders,
-        }
-      )
-      return { slug: foundSlug, percentageRated: scores.data?.[0]?.percentage_rated ?? null }
-    } catch {
-      return { slug: foundSlug, percentageRated: null }
+    return {
+      hasTeam: true,
+      slug: municipality.slug ?? null,
+      percentageRated: score?.percentage_rated ?? null,
+      published: score?.published === true,
     }
   } catch {
-    return { slug: null, percentageRated: null }
+    return { hasTeam: false, slug: null, percentageRated: null, published: false }
   }
 }
 
+function applyTeamInfo(teamInfo: {
+  hasTeam: boolean
+  slug: string | null
+  percentageRated: number | null
+  published: boolean
+}) {
+  existingSlug.value = teamInfo.slug
+  existingPercentageRated.value = teamInfo.percentageRated
+  existingScorePublished.value = teamInfo.published
+  hasExistingTeam.value = teamInfo.hasTeam
+}
+
 async function fetchGeoData(ars: string) {
-  if (!$stadtlandzahlAPI) return
+  if (!$stadtlandzahlAPI) return null
   geoLoading.value = true
   try {
     const data = await $stadtlandzahlAPI.fetchStatsByARS(ars)
@@ -452,67 +481,52 @@ async function fetchGeoData(ars: string) {
         selectedArea.value = { ...selectedArea.value, population: data.data_products.population_data.population }
       }
     }
+    return data
   } catch {
     // geo data optional — form still works without it
+    return null
   } finally {
     geoLoading.value = false
   }
 }
 
 // --- Initialise from ARS query param ---
-async function initFromQueryParams(ars: string, name?: string, slug?: string) {
+async function initFromQueryParams(ars: string, name?: string) {
   // Reset state before loading new area
   selectedArea.value = { name: name ?? ars, ars }
-  existingSlug.value = slug ?? null
+  existingSlug.value = null
   existingPercentageRated.value = null
+  existingScorePublished.value = false
   hasExistingTeam.value = false
   areaGeoData.value = null
 
-  // Always verify against Directus — the URL param may be stale or missing
-  const teamInfo = await checkExistingLocalteam(ars)
-  if (teamInfo.slug) {
-    existingSlug.value = teamInfo.slug
-    existingPercentageRated.value = teamInfo.percentageRated
-  }
-  hasExistingTeam.value = !!existingSlug.value
-
-  if ($stadtlandzahlAPI) {
-    geoLoading.value = true
-    try {
-      const data = await $stadtlandzahlAPI.fetchStatsByARS(ars)
-      if (data?.name) {
-        selectedArea.value = {
-          name: data.name,
-          ars: data.ars ?? ars,
-          prefix: data.prefix ?? undefined,
-          population: data.data_products?.population_data?.population ?? null,
-          state: data.state ?? null,
-        }
-      }
-      if (data?.geo_center || data?.geo_area) {
-        areaGeoData.value = {
-          geo_center: data.geo_center ?? null,
-          geo_area: data.geo_area ?? null,
-        }
-      }
-    } catch {
-      // keep name from query param
-    } finally {
-      geoLoading.value = false
+  // Resolve the ARS through StadtLandZahl first. Its catalog data provides the
+  // authoritative municipality slug even for older Directus records without ARS.
+  // URL-provided slugs are deliberately ignored because they can be stale or forged.
+  const data = await fetchGeoData(ars)
+  if (data?.name && selectedArea.value) {
+    selectedArea.value = {
+      ...selectedArea.value,
+      name: data.name,
+      ars: data.ars ?? ars,
+      prefix: data.prefix ?? undefined,
     }
   }
+  const trustedSlugs = (data?.stadtlandklima_data ?? []).map((item: any) => item.slug).filter(Boolean)
+  const teamInfo = await checkExistingLocalteam(ars, trustedSlugs)
+  applyTeamInfo(teamInfo)
 }
 
 onMounted(() => {
   const ars = route.query.ars as string | undefined
-  if (ars) initFromQueryParams(ars, route.query.name as string | undefined, route.query.slug as string | undefined)
+  if (ars) initFromQueryParams(ars, route.query.name as string | undefined)
 })
 
 watch(
   () => route.query.ars,
   (ars) => {
     if (ars) {
-      initFromQueryParams(ars as string, route.query.name as string | undefined, route.query.slug as string | undefined)
+      initFromQueryParams(ars as string, route.query.name as string | undefined)
     } else {
       resetSelection()
     }


### PR DESCRIPTION
# Lokalteam gründen: Kommunenauswahl und Bewertungsstatus

## Zusammenfassung

Das Formular unter `/register_localteam` vermischte bisher nicht bewertbare
Verwaltungsebenen mit Kommunen und leitete den Lokalteam- beziehungsweise
Bewertungsstatus aus mehreren uneinheitlichen Quellen ab. Dadurch konnten unter
anderem Bundesländer und Regierungsbezirke in der Kommunenauswahl erscheinen,
vorhandene oder fehlende Lokalteams falsch erkannt und unveröffentlichte
Bewertungen als abgeschlossen angezeigt werden.

Die Statuslogik verwendet nun ausschließlich die als `isCurrentBackend: true`
markierte Version des Maßnahmenkatalogs. Eine Bewertung gilt genau dann als
abgeschlossen, wenn der zugehörige Datensatz in dieser Katalogversion
veröffentlicht ist.

## Ursachen des vorherigen Verhaltens

### Gemischte Verwaltungsebenen in der Suche

Das Formular verwendete den Suchmodus `normal`. Dieser Modus liefert sowohl
Verwaltungsebenen 1 bis 3 als auch bewertbare Kommunen. Deshalb wurden neben
Gemeinden und Städten beispielsweise Bundesländer und Regierungsbezirke
angezeigt.

### Katalogunabhängige Bewertungsermittlung

Der Bewertungsstatus wurde teilweise aus externen StadtLandZahl-Daten, globalen
Listen veröffentlichter Slugs oder dem höchsten beziehungsweise ersten
gefundenen Bewertungsfortschritt abgeleitet. Diese Daten mussten nicht zur
aktuellen Backend-Version des Maßnahmenkatalogs gehören.

### Prozentwert als Abschlusskriterium

Ein Bewertungsfortschritt ab 98 Prozent wurde als abgeschlossen behandelt. Das
Feld `published` wurde dabei nicht zuverlässig berücksichtigt. Somit konnte eine
unveröffentlichte Bewertung als fertig erscheinen, während eine veröffentlichte
Bewertung unterhalb des Grenzwerts weiterhin als in Arbeit galt.

### Slug als Ersatz für die Teamexistenz

Die Existenz eines Lokalteams wurde teilweise über einen vorhandenen Slug
abgeleitet. Das führte in beide Richtungen zu Fehlern:

- Ein Slug aus der URL oder aus externen Bewertungsdaten konnte ein nicht
  vorhandenes Lokalteam vortäuschen.
- Ein vorhandenes Lokalteam ohne Municipality-Slug konnte als nicht existent
  behandelt werden.

Insbesondere ein veralteter oder manipulierter `slug`-Query-Parameter konnte das
Gründungsformular fälschlich durch den Hinweis auf ein bestehendes Team ersetzen.

### Kein eigener Zustand für null Prozent

Ein vorhandenes Lokalteam mit fehlendem Bewertungsdatensatz oder null Prozent
Fortschritt wurde genauso dargestellt wie eine tatsächlich begonnene Bewertung.

## Neue fachliche Regeln

Die Seite lädt genau eine sichtbare Katalogversion mit
`isCurrentBackend: true`. Ist die Directus-Konfiguration nicht eindeutig, wird
ein Fehler ausgelöst, statt stillschweigend eine beliebige Version zu verwenden.

Der Formularstatus wird anschließend nach folgender Reihenfolge bestimmt:

| Voraussetzung | Status | Darstellung und Aktion |
|---|---|---|
| Kein `localteam_id` vorhanden | `none` | Gründungsformular beziehungsweise „Jetzt Lokalteam gründen“ |
| Lokalteam vorhanden und Bewertung der aktuellen Version veröffentlicht | `complete` | „Bewertung abgeschlossen“, Bewertungslink soweit ein Slug vorhanden ist, zusätzlich Kontaktmöglichkeit |
| Lokalteam vorhanden, aktuelle Bewertung unveröffentlicht und Fortschritt größer als 0 Prozent | `in-progress` | „Lokalteam aktiv – Bewertung läuft“ und Kontaktmöglichkeit |
| Lokalteam vorhanden, aktuelle Bewertung fehlt oder steht bei 0 Prozent | `not-started` | „Lokalteam aktiv – Bewertung noch nicht begonnen“ und Kontaktmöglichkeit |

`published: true` hat Vorrang vor dem Prozentwert. Damit gilt auch eine
veröffentlichte Bewertung mit einem ungewöhnlich niedrigen Prozentwert als
abgeschlossen. Umgekehrt bleibt eine unveröffentlichte Bewertung selbst bei 98
oder 100 Prozent in Arbeit.

Bewertungen älterer oder zukünftiger Katalogversionen beeinflussen keinen dieser
Zustände.

## Verhalten vorher und jetzt

| Fall | Vorher | Jetzt |
|---|---|---|
| Suche nach „Bayern“ | Bundesland und Regierungsbezirke konnten erscheinen | Keine nicht bewertbaren höheren Ebenen |
| Bewertbarer Stadtstaat | Konnte wegen seiner Verwaltungsebene uneindeutig sein | Bleibt enthalten, wenn `isReasonableForMunicipalRating: true` gesetzt ist |
| Kommune ohne Lokalteam | Externer oder übergebener Slug konnte ein Team vortäuschen | Gründungsformular wird angezeigt, solange Directus keinen `localteam_id` bestätigt |
| Lokalteam ohne Slug | Konnte als nicht vorhanden gelten | Wird über `localteam_id` erkannt; nur der Bewertungslink entfällt |
| Lokalteam ohne Bewertung der aktuellen Version | Beliebige andere Version konnte den Status beeinflussen | „Bewertung noch nicht begonnen“ |
| Aktuelle Bewertung bei 0 Prozent, unveröffentlicht | „Bewertung läuft“ | „Bewertung noch nicht begonnen“ |
| Aktuelle Bewertung über 0 Prozent, unveröffentlicht | In Arbeit; ab 98 Prozent teilweise abgeschlossen | Immer „Bewertung läuft“ |
| Aktuelle Bewertung veröffentlicht | Unter 98 Prozent teilweise noch in Arbeit | Immer „Bewertung abgeschlossen“ |
| Nur eine ältere Version ist veröffentlicht | Konnte als abgeschlossen erscheinen | Aktuelle Backend-Version bestimmt den Status |
| Veralteter oder manipulierter URL-Slug | Konnte ein bestehendes Team vortäuschen | Wird nicht als Identitätsnachweis verwendet |

## Kommunenauswahl

Das Formular verwendet nun den Suchmodus `reasonable`. Dieser beschränkt die
Ergebnisse auf administrative Gebiete, die für eine kommunale Bewertung
vorgesehen sind.

Stadtstaaten wie Berlin können weiterhin erscheinen, obwohl sie technisch eine
höhere Verwaltungsebene besitzen. Sie sind gleichzeitig bewertbare Kommunen und
werden von StadtLandZahl entsprechend mit
`isReasonableForMunicipalRating: true` gekennzeichnet.

## Erkennung eines bestehenden Lokalteams

Ein Lokalteam gilt nur als vorhanden, wenn ein passender Municipality-Datensatz
in Directus einen nicht leeren `localteam_id` besitzt.

Zur Zuordnung werden verwendet:

1. Slugs aus dem StadtLandZahl-Suchergebnis beziehungsweise aus der über die ARS
   geladenen StadtLandZahl-Antwort.
2. Die amtliche ARS als Fallback.

Ein über die Seiten-URL gelieferter Slug wird bewusst ignoriert. Damit können
veraltete Links und frei manipulierbare Query-Parameter keine fremde Kommune oder
kein fremdes Lokalteam zuordnen.

Die Slug-Zuordnung bleibt notwendig, weil ältere durch Directus-Flows erzeugte
Municipality-Datensätze teilweise keine ARS besitzen.

## Änderungen im Code

- `src/frontend/pages/register_localteam.vue`
  - verwendet `currentVersionBackend`;
  - verwendet die eingeschränkte Kommunensuche;
  - führt die vier expliziten Zustände `none`, `not-started`, `in-progress` und
    `complete` ein;
  - prüft die Teamexistenz über `localteam_id`;
  - ignoriert URL-Slugs als Identitätsnachweis;
  - liest ausschließlich den Score der aktuellen Backend-Katalogversion.
- `src/frontend/composables/useAreaSearch.js`
  - kann Team- und Bewertungsstatus für eine konkrete Directus-Katalogversion
    anreichern;
  - unterscheidet in Suchergebnissen zwischen nicht begonnen, in Arbeit,
    veröffentlicht und ohne Team.
- `src/frontend/components/AreaSearchResult.vue`
  - zeigt einen eigenen Chip für „Bewertung noch nicht begonnen“.
- `src/frontend/composables/getCatalogVersion.js`
  - stellt eine eindeutige Abfrage für die aktuelle Backend-Katalogversion bereit.
- `src/directus/translations/{de-DE,en-GB,it-IT}/`
  - enthält die neuen Texte in Deutsch, Englisch und Italienisch.
- `bin/test_suite/src/flows/registerLocalteamFlow.ts`
  - deckt die Kommunensuche, null Prozent, begonnene unveröffentlichte
    Bewertungen, veröffentlichte Bewertungen und manipulierte URL-Slugs ab.

## Verifikation

Folgende Prüfungen wurden erfolgreich durchgeführt:

- Directus-Übersetzungen über `import-all.sh` importiert;
- Register-Flow einschließlich Setup und Cleanup: 8 von 8 Schritten erfolgreich;
- Nuxt-Produktionsbuild erfolgreich;
- TypeScript-Prüfung erfolgreich;
- JavaScript-Syntax- und Git-Diff-Prüfungen erfolgreich;
- `/register_localteam` auf `localhost:8080` antwortet mit HTTP 200;
- `/api/area-search?term=Bayern&mode=reasonable` liefert keine nicht
  bewertbaren höheren Verwaltungsebenen.

Der vollständige Lauf von `bin/test_dev.sh` wurde mehrfach gestartet. Er blieb
in zwei Folgeläufen in einem unveränderten Wahlcheck-Browsertest hängen, bevor
die Register-Tests erreicht wurden. Dort wurde ein dynamisch erzeugtes
`question-…`-Eingabefeld nicht innerhalb von 30 Sekunden sichtbar. Derselbe
Wahlcheck-Schritt war im ersten Lauf erfolgreich. Die separat ausgeführten neuen
Register-Szenarien sind vollständig grün.
